### PR TITLE
tests: align generated+default materialization with write_defaults

### DIFF
--- a/tests/level-1/generated-default-interaction.yaml
+++ b/tests/level-1/generated-default-interaction.yaml
@@ -295,9 +295,8 @@ groups:
           # code should be a UUID, not "NONE"
           frontmatter_not_match:
             code: "NONE"
-          frontmatter_written: [code]
-          # category has only default, no generated — suppressed from disk
-          frontmatter_not_written: [category]
+          frontmatter_written: [code, category]
+          # category has only default. with write_defaults=true (default), it is materialized.
 
   # =============================================================================
   # Group 6: Derived generated field with default fallback


### PR DESCRIPTION
## Summary
Align a conformance expectation with current `write_defaults` semantics.

- In `generated-default-interaction.yaml`, the test `create uses generated value not default` now expects both `code` and `category` to be written.
- `category` is default-only and should be materialized when `write_defaults` is `true` (default).

## Why
Spec text says default-only fields are written when `write_defaults` is true, but this test previously expected omission for `category`.

Fixes #11
