### PR TITLE
Define portable saved views and Obsidian Bases compatibility

### DIFF
--- a/11-querying.md
+++ b/11-querying.md
@@ -264,11 +264,9 @@ empty object.
 
 ## Saved View Records
 
-A saved view is an ordinary Markdown record matched by the `view` type. It is
-not a runtime contract and does not introduce a second query language or query
-engine. The specification does not define a separate persisted query-record
-kind: a query is the reusable value object above, and a view record is its
-portable persisted container. The canonical record schema is
+A saved view is an ordinary Markdown record matched by the `view` type. The
+canonical query object above supplies its execution semantics, and the view
+record provides a portable persisted container. The canonical record schema is
 `schemas/v0.3/view.schema.json`; a collection can materialize the corresponding
 `_types/view.md` type file.
 
@@ -329,13 +327,14 @@ Record-level property metadata and summary functions remain available to every
 named view. Resolving an unknown view record or named-view ID produces
 `view_not_found`.
 
-View execution returns the ordinary query envelope and adds
+View execution returns the query envelope and adds
 `meta.view: { path, id }`, using the resolved view-record path and named-view
-ID. It does not introduce a second result format.
+ID.
 
 Property-metadata keys MAY name effective fields, `file.*` values,
 `projection.*` values, or selection outputs. They provide labels, descriptions,
-format hints, and visibility hints only; they do not add values to `select`.
+format hints, and visibility hints. `select` remains the source of result
+values.
 
 ### View invocation context
 
@@ -380,20 +379,18 @@ available to presentation without giving presentation its own projection
 language. A named view with no `presentation` is a complete headless saved
 query.
 
-Presentation metadata MUST NOT affect filtering, projection, ordering,
-grouping, summaries, pagination, or the headless result envelope. An unknown
-renderer does not prevent headless execution. A request that specifically asks
-for unavailable rendering reports `unsupported_presentation` and may use the
-declared fallback.
+Presentation metadata is advisory. Filtering, projection, ordering, grouping,
+summaries, pagination, and the headless result envelope retain their canonical
+query semantics. Headless execution succeeds for every renderer identifier. A
+request for rendered output reports `unsupported_presentation` when neither the
+requested renderer nor its declared fallback is available.
 
-Tool-specific source syntax, renderer configuration, and round-trip data use
-`x-*` extensions. An Obsidian Bases adapter, for example, may translate Bases
-filters and formulas to portable CEL while preserving untranslatable source
-under `x-obsidian`.
+Source syntax, renderer configuration, and round-trip data use `x-*`
+extensions. Chapter 15 defines the adapter contract for Obsidian Bases sources.
 
 ### Optional support
 
-All Core Read implementations treat a view file as an ordinary typed record.
-A tool advertises `view_records` in its existing `optional_features` claim only
-when it resolves and executes named views with the semantics in this chapter.
-No runtime profile is required.
+Core Read implementations treat a canonical view file as an ordinary typed
+record. A tool advertises `view_records` in its `optional_features` claim when
+it resolves, lists, and executes named views with the semantics in this
+chapter.

--- a/12-operations.md
+++ b/12-operations.md
@@ -14,6 +14,11 @@ Core operations:
 - rename
 - batch
 
+Optional saved-view operations:
+
+- list_views
+- execute_view
+
 ## Read
 
 Read returns a record by path, including:
@@ -102,6 +107,64 @@ Recommended behavior:
 - support dry-run with full diagnostics
 - report per-operation result and diagnostics
 - stop on first error unless configured otherwise
+
+## Saved Views
+
+`list_views` discovers the saved-view sources available through the collection
+provider. Its result has this shape:
+
+```yaml
+valid: true
+result:
+  views:
+    - id: task.views
+      name: Task views
+      source:
+        path: views/tasks.md
+        format: mdbase.view
+        revision: opaque-source-revision
+        writable: true
+      views:
+        - id: today
+          name: Today
+          presentation:
+            type: tasknotes.task-list
+  meta:
+    total_count: 1
+diagnostics: []
+```
+
+`source.path` is a collection-relative path. `source.format` is a stable source
+format identifier. `source.revision` is an opaque token for the source content.
+`source.writable` describes whether the provider accepts writes for that source
+format. Each nested descriptor exposes the stable named-view ID, its display
+name, and its optional presentation metadata. Discovery order is ascending by
+source path and then source-defined named-view order.
+
+Malformed configured sources are omitted from `result.views` and reported as
+warning diagnostics. Reading a malformed source explicitly produces
+`invalid_view`.
+
+`execute_view` accepts:
+
+```yaml
+path: views/tasks.md
+view: today
+context:
+  path: projects/alpha.md
+limit: 50
+offset: 0
+render: false
+```
+
+`path` and `view` select a descriptor returned by `list_views`. `context` binds
+the invocation context defined in Chapter 11. `limit` and `offset` override the
+named view's pagination for this invocation. The provider evaluates the
+source's declared expression dialect and returns the query result envelope with
+`meta.view`.
+
+`render: false` requests the headless result and is the default. `render: true`
+requests renderer output using the selected presentation metadata.
 
 ## Concurrency
 

--- a/15-migrations-and-compatibility.md
+++ b/15-migrations-and-compatibility.md
@@ -87,9 +87,34 @@ exports.
 
 ## Obsidian Bases Views
 
-Obsidian `.base` files are compatibility inputs, not mdbase records required by
-Core Read. An adapter may import, execute, or export them through the ordinary
-view-record model from Chapter 11.
+Obsidian `.base` files are external saved-view sources. A collection provider
+discovers configured sources and exposes them through the saved-view operations
+in Chapter 12. Core Read continues to discover records through the collection's
+record extensions.
+
+Collections enable discovery with a namespaced configuration section:
+
+```yaml
+x-obsidian:
+  bases:
+    include:
+      - TaskNotes/Views/**/*.base
+    create_folder: TaskNotes/Views
+    default_for_new_views: true
+```
+
+`include` contains collection-relative glob patterns. The provider MUST apply
+the same path-boundary and symlink protections used for record discovery.
+`create_folder` identifies the preferred location for new Obsidian sources.
+`default_for_new_views` makes that source format the collection's default when
+a view-creation interface offers no explicit format. Providers advertising
+write support use these values when creating a source.
+
+The `.base` file remains authoritative for a discovered Obsidian source.
+`list_views` returns `source.format: obsidian.base`, a revision derived from the
+source bytes, and a stable named-view ID for each contained view. Stable IDs are
+derived deterministically from view names when the source format supplies no
+ID. Collisions receive deterministic source-order suffixes.
 
 The structural mapping is:
 
@@ -107,19 +132,25 @@ The structural mapping is:
 | view `type` | `presentation.type` |
 | plugin view keys | presentation options or `x-*` extension data |
 
-An adapter SHOULD parse the source dialect into an inspectable syntax tree and
-translate it to CEL only when behavior can be preserved. A partial translation
-MUST report unsupported expressions, functions, value coercions, or renderer
-features. It MUST NOT silently label a behavior-changing translation as
-portable. Lossless source and round-trip metadata may be retained under
-`x-obsidian`.
+Executing an Obsidian source evaluates its filters and formulas with Obsidian
+Bases expression semantics. The adapter parses the source dialect into an
+inspectable syntax tree and applies the source dialect's value coercion, date,
+link, file, formula, and error behavior. Translation to canonical CEL is an
+export operation and succeeds only when behavior is preserved. Translation
+diagnostics identify unsupported expressions, functions, coercions, or
+renderer features. Lossless source and round-trip metadata may be retained
+under `x-obsidian`.
+
+Execution returns the headless result envelope from Chapter 12. Selected and
+presentation-mapped values appear under each row's `values`; renderer metadata
+may approximate layout while retaining the source's filtering, formula,
+ordering, grouping, and pagination semantics.
 
 Obsidian placement state maps to the portable invocation context rather than to
 query semantics: opening a Base directly supplies the view definition, an
 embed supplies its embedding record, and an active-file interface supplies its
-active record. The adapter resolves that host state before calling the query or
-view executor. Portable mdbase execution does not inspect editor workspace
-state.
+active record. The adapter resolves that host state into an explicit invocation
+context before calling the query or view executor.
 
 ## Runtime Workflows
 

--- a/16-conformance.md
+++ b/16-conformance.md
@@ -166,11 +166,10 @@ Query implementations MUST:
 
 ## View Record Optional Feature
 
-View records do not define a separate conformance profile. They are ordinary
-typed records and require no runtime profile. An implementation advertises
-`view_records` through the existing `optional_features` member only when it:
+An implementation advertises `view_records` through `optional_features` when it:
 
 - validates view frontmatter against the canonical view schema
+- lists view records with stable source and named-view descriptors
 - resolves a stable view-record ID or path plus a stable named-view ID
 - rejects duplicate named-view IDs with `invalid_view`
 - derives the executable query using the inheritance and merge rules in
@@ -178,12 +177,32 @@ typed records and require no runtime profile. An implementation advertises
 - applies `context.this.on_missing` and context type constraints before query
   execution
 - reports the selected view and resolved context in query result metadata
-- treats presentation metadata as advisory and preserves headless results when
-  a renderer is unavailable
+- applies presentation metadata as advisory input while preserving canonical
+  headless results
 - keeps alternate dialect and renderer-specific data under `x-*` extensions
 
 A tool MAY advertise supported presentation identifiers separately in
-`optional_features`. Presentation support is not required for `view_records`.
+`optional_features`.
+
+An implementation advertises `obsidian_bases_views` through
+`optional_features` when it:
+
+- discovers `.base` sources selected by `x-obsidian.bases.include`
+- assigns deterministic named-view IDs and source revisions
+- parses filters and formulas before candidate evaluation
+- evaluates the Obsidian Bases expression dialect, including formula
+  dependencies, file and link values, date and duration behavior, methods, and
+  coercions
+- combines source and named-view filters with AND
+- applies source order, sort, group, limit, and presentation metadata
+- returns the saved-view headless result envelope
+- keeps `.base` sources authoritative throughout discovery and execution
+
+Conformance suites for `obsidian_bases_views` MUST include an oracle corpus
+captured from the supported Obsidian expression environment. Each case records
+the expression, evaluation context, expected value or error, and source
+environment version. Known upstream divergences are identified individually in
+the corpus.
 
 ## Links Requirements
 

--- a/tests/v0.3/README.md
+++ b/tests/v0.3/README.md
@@ -82,6 +82,7 @@ Future v0.3 adapters should support these operations:
 - `read`
 - `validate`
 - `query`
+- `list_views`
 - `execute_view`
 - `evaluate_cel`
 - `create`

--- a/tests/v0.3/views/view-records.yaml
+++ b/tests/v0.3/views/view-records.yaml
@@ -200,6 +200,35 @@ groups:
               name: Second
           ---
     tests:
+      - name: "view discovery returns stable source and named-view descriptors"
+        operation: list_views
+        input: {}
+        expect:
+          valid: true
+          views:
+            - id: task.views
+              name: Task views
+              source:
+                path: views/tasks.md
+                format: mdbase.view
+                writable: true
+              views:
+                - id: project-open
+                  name: Open tasks for project
+                  presentation:
+                    type: tasknotes.task-list
+                - id: direct
+                  name: Direct invocation
+                - id: optional
+                  name: Optional context
+                - id: context-shape
+                  name: Complete context shape
+          meta:
+            total_count: 1
+          diagnostics:
+            - code: invalid_view
+              severity: warning
+
       - name: "explicit context is fixed while candidates change"
         id: views.explicit_context
         covers:
@@ -281,6 +310,17 @@ groups:
             - tasks/alpha-done.md
             - tasks/alpha-open.md
             - tasks/beta-open.md
+
+      - name: "an explicit null context overrides the view default"
+        operation: execute_view
+        input:
+          path: views/tasks.md
+          view: direct
+          context: null
+        expect:
+          valid: true
+          context: null
+          paths: []
 
       - name: "optional missing context binds this to null"
         operation: execute_view
@@ -387,6 +427,57 @@ groups:
             second:
               expr: 'projection.first'
           select: [projection.first]
+        expect:
+          valid: false
+          diagnostics:
+            - code: invalid_query
+
+      - name: "computed named-projection references participate in cycle detection"
+        operation: query
+        input:
+          types: [task]
+          projections:
+            first:
+              expr: 'projection["second"]'
+            second:
+              expr: 'projection["first"]'
+          select: [projection.first]
+        expect:
+          valid: false
+          diagnostics:
+            - code: invalid_query
+
+      - name: "projection-like text inside a string is not a dependency"
+        operation: query
+        input:
+          types: [task]
+          projections:
+            first:
+              expr: '"projection.second"'
+            second:
+              expr: 'projection.first'
+          select: [projection.second]
+        expect:
+          valid: true
+          results:
+            - path: tasks/alpha-done.md
+              values:
+                second: projection.second
+            - path: tasks/alpha-open.md
+              values:
+                second: projection.second
+            - path: tasks/archived.md
+              values:
+                second: projection.second
+            - path: tasks/beta-open.md
+              values:
+                second: projection.second
+
+      - name: "invalid CEL syntax fails query preflight"
+        operation: query
+        input:
+          types: [missing-type]
+          where: 'status =='
         expect:
           valid: false
           diagnostics:


### PR DESCRIPTION
## What changed

- define portable saved-view discovery and execution
- specify Obsidian Bases compatibility as an external view source
- add shared conformance cases for context, projections, diagnostics, and syntax preflight

## Why

Applications need one provider-neutral view contract while collection providers retain responsibility for source discovery and exact expression execution.

## Validation

- shared fixture passes in the TypeScript and Rust implementations
- specification diff check passes
