### PR TITLE
Define ordered saved-view properties

### DIFF
--- a/11-querying.md
+++ b/11-querying.md
@@ -379,6 +379,10 @@ available to presentation without giving presentation its own projection
 language. A named view with no `presentation` is a complete headless saved
 query.
 
+Saved-view discovery exposes the selected outputs as ordered property
+descriptors. A renderer uses those descriptors to preserve selection order and
+labels while reading the corresponding values from each result row.
+
 Presentation metadata is advisory. Filtering, projection, ordering, grouping,
 summaries, pagination, and the headless result envelope retain their canonical
 query semantics. Headless execution succeeds for every renderer identifier. A

--- a/12-operations.md
+++ b/12-operations.md
@@ -127,6 +127,11 @@ result:
       views:
         - id: today
           name: Today
+          properties:
+            - key: title
+              label: Task
+            - key: urgency
+              label: Urgency
           presentation:
             type: tasknotes.task-list
   meta:
@@ -140,6 +145,13 @@ format identifier. `source.revision` is an opaque token for the source content.
 format. Each nested descriptor exposes the stable named-view ID, its display
 name, and its optional presentation metadata. Discovery order is ascending by
 source path and then source-defined named-view order.
+
+`properties` lists the named view's result values in display order. Each entry
+has the result `key` and may include `label`, `description`, `format`, and
+`hidden` metadata. Canonical view records derive this list from `select`.
+Compatible external sources derive it from their ordered property list and
+property metadata. Projection and formula results use the same descriptors as
+persisted fields.
 
 Malformed configured sources are omitted from `result.views` and reported as
 warning diagnostics. Reading a malformed source explicitly produces

--- a/16-conformance.md
+++ b/16-conformance.md
@@ -174,6 +174,7 @@ An implementation advertises `view_records` through `optional_features` when it:
 - rejects duplicate named-view IDs with `invalid_view`
 - derives the executable query using the inheritance and merge rules in
   Chapter 11
+- exposes selected result properties in display order with their metadata
 - applies `context.this.on_missing` and context type constraints before query
   execution
 - reports the selected view and resolved context in query result metadata
@@ -195,6 +196,7 @@ An implementation advertises `obsidian_bases_views` through
   coercions
 - combines source and named-view filters with AND
 - applies source order, sort, group, limit, and presentation metadata
+- exposes the source's ordered properties and display names
 - returns the saved-view headless result envelope
 - keeps `.base` sources authoritative throughout discovery and execution
 

--- a/tests/v0.3/views/view-records.yaml
+++ b/tests/v0.3/views/view-records.yaml
@@ -117,6 +117,11 @@ groups:
           id: task.views
           version: 1
           name: Task views
+          properties:
+            title:
+              label: Task
+            projection.contextual_title:
+              label: Contextual title
           query:
             types: [task]
             where: 'status != "archived"'
@@ -215,6 +220,11 @@ groups:
               views:
                 - id: project-open
                   name: Open tasks for project
+                  properties:
+                    - key: title
+                      label: Task
+                    - key: contextual_title
+                      label: Contextual title
                   presentation:
                     type: tasknotes.task-list
                 - id: direct


### PR DESCRIPTION
## What changed

- add ordered result-property descriptors to saved-view discovery
- retain labels and other property metadata for fields and projections
- extend the shared conformance fixture

## Why

Renderers need an explicit display contract rather than inferring order from serialized row objects.

## Validation

- shared fixture passes in TypeScript and Rust
- specification guardrail diff check
