### PR TITLE
Add dark mode to mdbase.dev

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,6 +10,16 @@ colors:
   ink-muted: "oklch(54% 0.014 255)"
   line: "oklch(92% 0.006 255)"
   blue-accent: "oklch(45% 0.105 238)"
+dark-colors:
+  paper: "oklch(18.5% 0.012 255)"
+  paper-soft: "oklch(20.5% 0.013 255)"
+  paper-code: "oklch(21.5% 0.014 255)"
+  ink: "oklch(92% 0.008 255)"
+  ink-soft: "oklch(79% 0.01 255)"
+  ink-muted: "oklch(67% 0.012 255)"
+  line: "oklch(29% 0.012 255)"
+  line-strong: "oklch(40% 0.014 255)"
+  blue-accent: "oklch(73% 0.105 238)"
 typography:
   display:
     fontFamily: "Atkinson Hyperlegible, Segoe UI, sans-serif"
@@ -63,7 +73,7 @@ components:
 
 **Creative North Star: "A Clean Standards Document"**
 
-mdbase.dev is a calm, precise reading environment for people who implement the specification. White space, direct typography, pale rules, and real mdbase artifacts give the site its identity. The visual system keeps attention on the model, examples, and normative text.
+mdbase.dev is a calm, precise reading environment for people who implement the specification. Open space, direct typography, quiet rules, and real mdbase artifacts give the site its identity. The visual system keeps attention on the model, examples, and normative text in daylight or low light.
 
 ### Key characteristics
 
@@ -76,7 +86,9 @@ mdbase.dev is a calm, precise reading environment for people who implement the s
 
 ## 2. Colors
 
-The palette is white with blue-black ink. Hierarchy comes from type, spacing, and pale rules.
+The light palette is paper with blue-black ink. The dark palette uses deep
+blue-black paper with softened light ink. Hierarchy comes from type, spacing,
+and quiet rules in both themes.
 
 ### Primary
 
@@ -92,7 +104,18 @@ The palette is white with blue-black ink. Hierarchy comes from type, spacing, an
 
 ### Color rule
 
-Use blue for links, focus, and selected states. Keep actions white with restrained outlines or text treatment.
+Use blue for links, focus, and selected states. Keep actions on the current
+surface with restrained outlines or text treatment.
+
+### Theme contract
+
+Every page offers System, Light, and Dark. System follows
+`prefers-color-scheme`; an explicit choice is stored locally as `mdbase:theme`
+and applied before the stylesheet to prevent a flash. Components consume
+canvas, surface, surface-subtle, text, text-soft, text-muted, border,
+border-strong, accent, success, and danger roles rather than fixed palette
+values. Dark mode uses blue-black surfaces, not pure black, with lighter syntax
+and link colors for long-form reading.
 
 ## 3. Typography
 
@@ -122,7 +145,7 @@ Whitespace carries hierarchy at page scale. Within resource lists and the specif
 
 ## 5. Components
 
-- **Primary button:** white surface, pale neutral border, ink text, 3px radius, 44px minimum height.
+- **Primary button:** current surface, quiet neutral border, ink text, 3px radius, 44px minimum height.
 - **Secondary button:** the same light structure with quieter border emphasis.
 - **Resource row:** top rule with label, name, description, capabilities, and link aligned in columns.
 - **Code specimen:** paper-code surface, fine border, compact mono text, and restrained syntax colors.

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -22,9 +22,15 @@ const STYLE_VERSION = createHash('sha256')
   .update(readFileSync(join(STATIC, 'style.css')))
   .digest('hex')
   .slice(0, 12);
+const THEME_VERSION = createHash('sha256')
+  .update(readFileSync(join(STATIC, 'theme.js')))
+  .digest('hex')
+  .slice(0, 12);
 
 function versionAssets(html) {
-  return html.replaceAll('style.css', `style.css?v=${STYLE_VERSION}`);
+  return html
+    .replaceAll('style.css', `style.css?v=${STYLE_VERSION}`)
+    .replaceAll('theme.js', `theme.js?v=${THEME_VERSION}`);
 }
 
 // ---------------------------------------------------------------------------

--- a/site/static/style.css
+++ b/site/static/style.css
@@ -5,20 +5,33 @@
 :root {
   color-scheme: light;
 
-  --paper: oklch(100% 0 0);
-  --paper-soft: oklch(100% 0 0);
-  --paper-code: oklch(100% 0 0);
-
-  --ink: oklch(21% 0.018 255);
-  --ink-soft: oklch(39% 0.016 255);
-  --ink-muted: oklch(54% 0.014 255);
-  --line: oklch(92% 0.006 255);
-  --line-strong: oklch(82% 0.008 255);
-
-  --accent: oklch(45% 0.105 238);
-  --accent-dark: oklch(35% 0.09 238);
-  --green: oklch(43% 0.09 153);
-  --violet: oklch(44% 0.075 294);
+  --color-canvas: oklch(99.7% 0.002 255);
+  --color-surface: oklch(99.7% 0.002 255);
+  --color-surface-subtle: oklch(98.5% 0.004 255);
+  --color-surface-code: oklch(98.8% 0.004 255);
+  --color-text: oklch(21% 0.018 255);
+  --color-text-soft: oklch(39% 0.016 255);
+  --color-text-muted: oklch(54% 0.014 255);
+  --color-border: oklch(92% 0.006 255);
+  --color-border-strong: oklch(82% 0.008 255);
+  --color-accent: oklch(45% 0.105 238);
+  --color-accent-strong: oklch(35% 0.09 238);
+  --color-success: oklch(43% 0.09 153);
+  --color-violet: oklch(44% 0.075 294);
+  --color-on-accent: oklch(98% 0.004 255);
+  --color-scrim: oklch(21% 0.018 255 / 0.22);
+  --paper: var(--color-surface);
+  --paper-soft: var(--color-surface-subtle);
+  --paper-code: var(--color-surface-code);
+  --ink: var(--color-text);
+  --ink-soft: var(--color-text-soft);
+  --ink-muted: var(--color-text-muted);
+  --line: var(--color-border);
+  --line-strong: var(--color-border-strong);
+  --accent: var(--color-accent);
+  --accent-dark: var(--color-accent-strong);
+  --green: var(--color-success);
+  --violet: var(--color-violet);
 
   --sans: 'Atkinson Hyperlegible', 'Segoe UI', sans-serif;
   --mono: 'Azeret Mono', 'SFMono-Regular', 'Cascadia Code', monospace;
@@ -38,6 +51,46 @@
   --sidebar: 17rem;
   --header: 3.5rem;
   --ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --color-canvas: oklch(17.5% 0.012 255);
+  --color-surface: oklch(18.5% 0.012 255);
+  --color-surface-subtle: oklch(20.5% 0.013 255);
+  --color-surface-code: oklch(21.5% 0.014 255);
+  --color-text: oklch(92% 0.008 255);
+  --color-text-soft: oklch(79% 0.01 255);
+  --color-text-muted: oklch(67% 0.012 255);
+  --color-border: oklch(29% 0.012 255);
+  --color-border-strong: oklch(40% 0.014 255);
+  --color-accent: oklch(73% 0.105 238);
+  --color-accent-strong: oklch(80% 0.085 238);
+  --color-success: oklch(75% 0.085 153);
+  --color-violet: oklch(76% 0.075 294);
+  --color-on-accent: oklch(17% 0.012 255);
+  --color-scrim: oklch(5% 0.008 255 / 0.6);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    color-scheme: dark;
+    --color-canvas: oklch(17.5% 0.012 255);
+    --color-surface: oklch(18.5% 0.012 255);
+    --color-surface-subtle: oklch(20.5% 0.013 255);
+    --color-surface-code: oklch(21.5% 0.014 255);
+    --color-text: oklch(92% 0.008 255);
+    --color-text-soft: oklch(79% 0.01 255);
+    --color-text-muted: oklch(67% 0.012 255);
+    --color-border: oklch(29% 0.012 255);
+    --color-border-strong: oklch(40% 0.014 255);
+    --color-accent: oklch(73% 0.105 238);
+    --color-accent-strong: oklch(80% 0.085 238);
+    --color-success: oklch(75% 0.085 153);
+    --color-violet: oklch(76% 0.075 294);
+    --color-on-accent: oklch(17% 0.012 255);
+    --color-scrim: oklch(5% 0.008 255 / 0.6);
+  }
 }
 
 *,
@@ -80,7 +133,7 @@ body {
 }
 
 ::selection {
-  color: var(--paper);
+  color: var(--color-on-accent);
   background: var(--accent);
 }
 
@@ -141,7 +194,7 @@ strong {
 
 a {
   color: var(--accent-dark);
-  text-decoration-color: oklch(45% 0.105 238 / 0.28);
+  text-decoration-color: color-mix(in oklch, var(--accent) 28%, transparent);
   text-decoration-thickness: 1px;
   text-underline-offset: 0.18em;
   transition:
@@ -312,6 +365,35 @@ td {
   display: flex;
   align-items: center;
   gap: var(--space-lg);
+}
+
+.spec-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-lg);
+}
+
+.theme-select {
+  width: 5.2rem;
+  min-height: 2.25rem;
+  padding: 0 1.35rem 0 0.45rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  color: var(--ink-soft);
+  background: var(--paper);
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  cursor: pointer;
+}
+
+.theme-select:hover {
+  border-color: var(--line-strong);
+  color: var(--ink);
+}
+
+.theme-select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
 }
 
 .landing-nav a {
@@ -873,7 +955,7 @@ td {
     display: block;
     width: 100%;
     border: 0;
-    background: oklch(21% 0.018 255 / 0.22);
+    background: var(--color-scrim);
   }
 
   .sidebar-scrim[hidden] {
@@ -891,6 +973,10 @@ td {
 
   .spec-header .landing-nav {
     display: none;
+  }
+
+  .spec-header-actions {
+    gap: var(--space-sm);
   }
 
 }
@@ -995,6 +1081,14 @@ td {
 
 @media (max-width: 36rem) {
   .landing-header .landing-nav a:not(.nav-cta) {
+    display: none;
+  }
+
+  .landing-nav {
+    gap: var(--space-xs);
+  }
+
+  .spec-version {
     display: none;
   }
 

--- a/site/static/theme.js
+++ b/site/static/theme.js
@@ -1,0 +1,42 @@
+(() => {
+  const storageKey = "mdbase:theme";
+  const root = document.documentElement;
+  const media = matchMedia("(prefers-color-scheme: dark)");
+  let preference = "system";
+
+  try {
+    const stored = localStorage.getItem(storageKey);
+    if (stored === "light" || stored === "dark" || stored === "system") preference = stored;
+  } catch {
+    // The system preference remains available when local storage is unavailable.
+  }
+
+  function apply(next, persist = false) {
+    preference = next;
+    if (next === "system") root.removeAttribute("data-theme");
+    else root.dataset.theme = next;
+    if (persist) {
+      try {
+        localStorage.setItem(storageKey, next);
+      } catch {
+        // Keep the in-memory selection for this page.
+      }
+    }
+    const dark = next === "dark" || (next === "system" && media.matches);
+    document.querySelector('meta[name="theme-color"]')?.setAttribute("content", dark ? "#1b1d23" : "#fdfdfd");
+    document.querySelectorAll("[data-theme-select]").forEach((select) => {
+      select.value = next;
+    });
+  }
+
+  apply(preference);
+  media.addEventListener("change", () => {
+    if (preference === "system") apply("system");
+  });
+  addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll("[data-theme-select]").forEach((select) => {
+      select.value = preference;
+      select.addEventListener("change", (event) => apply(event.currentTarget.value, true));
+    });
+  });
+})();

--- a/site/templates/ecosystem.html
+++ b/site/templates/ecosystem.html
@@ -9,7 +9,9 @@
   <meta property="og:description" content="Implementations, tools, and projects built around the mdbase specification.">
   <meta property="og:url" content="https://mdbase.dev/ecosystem">
   <meta property="og:type" content="website">
+  <meta name="theme-color" content="#fdfdfd">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9670;</text></svg>">
+  <script src="theme.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="site-page">
@@ -24,6 +26,7 @@
       <a href="runtime.html">Runtime</a>
       <a href="ecosystem.html" class="nav-active">Ecosystem</a>
       <a href="https://github.com/callumalpass/mdbase-spec" class="hide-mobile">GitHub</a>
+      <select class="theme-select" aria-label="Color theme" data-theme-select><option value="system">System</option><option value="light">Light</option><option value="dark">Dark</option></select>
       <a href="spec.html" class="nav-cta">Read the spec</a>
     </nav>
   </header>

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -9,7 +9,9 @@
   <meta property="og:description" content="A specification for treating folders of Markdown files as typed, queryable data collections.">
   <meta property="og:url" content="https://mdbase.dev">
   <meta property="og:type" content="website">
+  <meta name="theme-color" content="#fdfdfd">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9670;</text></svg>">
+  <script src="theme.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="site-page">
@@ -19,6 +21,7 @@
       <a href="runtime.html">Runtime</a>
       <a href="ecosystem.html">Ecosystem</a>
       <a href="https://github.com/callumalpass/mdbase-spec" class="hide-mobile">GitHub</a>
+      <select class="theme-select" aria-label="Color theme" data-theme-select><option value="system">System</option><option value="light">Light</option><option value="dark">Dark</option></select>
       <a href="spec.html" class="nav-cta">Read the spec</a>
     </nav>
   </header>

--- a/site/templates/runtime.html
+++ b/site/templates/runtime.html
@@ -9,7 +9,9 @@
   <meta property="og:description" content="Portable automation contracts for typed Markdown collections.">
   <meta property="og:url" content="https://mdbase.dev/runtime">
   <meta property="og:type" content="website">
+  <meta name="theme-color" content="#fdfdfd">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9670;</text></svg>">
+  <script src="theme.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="site-page runtime-page">
@@ -20,6 +22,7 @@
       <a href="runtime.html" class="nav-active">Runtime</a>
       <a href="ecosystem.html">Ecosystem</a>
       <a href="https://github.com/callumalpass/mdbase-spec" class="hide-mobile">GitHub</a>
+      <select class="theme-select" aria-label="Color theme" data-theme-select><option value="system">System</option><option value="light">Light</option><option value="dark">Dark</option></select>
       <a href="spec.html" class="nav-cta">Read the spec</a>
     </nav>
   </header>

--- a/site/templates/spec.html
+++ b/site/templates/spec.html
@@ -5,7 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{SPEC_TITLE}} - mdbase</title>
   <meta name="description" content="The full mdbase specification for typed markdown collections.">
+  <meta name="theme-color" content="#fdfdfd">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9670;</text></svg>">
+  <script src="theme.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -21,13 +23,16 @@
       </a>
       <span class="spec-version">{{SPEC_VERSION}}</span>
     </div>
-    <nav class="landing-nav" aria-label="Spec links">
-      <a href="/">Home</a>
-      <a href="runtime.html">Runtime</a>
-      <a href="ecosystem.html">Ecosystem</a>
-      {{SPEC_SWITCH_LINK}}
-      <a href="https://github.com/callumalpass/mdbase-spec">GitHub</a>
-    </nav>
+    <div class="spec-header-actions">
+      <select class="theme-select" aria-label="Color theme" data-theme-select><option value="system">System</option><option value="light">Light</option><option value="dark">Dark</option></select>
+      <nav class="landing-nav" aria-label="Spec links">
+        <a href="/">Home</a>
+        <a href="runtime.html">Runtime</a>
+        <a href="ecosystem.html">Ecosystem</a>
+        {{SPEC_SWITCH_LINK}}
+        <a href="https://github.com/callumalpass/mdbase-spec">GitHub</a>
+      </nav>
+    </div>
   </header>
 
   <button class="sidebar-scrim" id="sidebar-scrim" type="button" aria-label="Close section navigation" hidden></button>


### PR DESCRIPTION
## What changed

- adds a persisted `system` / `light` / `dark` appearance control to every site template
- applies the preferred theme before first paint and follows system changes
- introduces semantic dark-mode tokens for the landing, ecosystem, runtime, and spec pages
- fingerprints the new theme script in production builds

## Why

mdbase.dev should complete the ecosystem-wide theme experience and keep long-form specification reading comfortable in dark environments.

## Validation

- `npm ci`
- `npm run build`
- desktop and mobile visual verification