### PR TITLE
Specify writable saved view sources

### DIFF
--- a/12-operations.md
+++ b/12-operations.md
@@ -18,6 +18,10 @@ Optional saved-view operations:
 
 - list_views
 - execute_view
+- read_view_source
+- create_view_source
+- update_view_source
+- delete_view_source
 
 ## Read
 
@@ -177,6 +181,41 @@ source's declared expression dialect and returns the query result envelope with
 
 `render: false` requests the headless result and is the default. `render: true`
 requests renderer output using the selected presentation metadata.
+
+### Saved-view source operations
+
+A provider that advertises a source as `writable: true` MUST support the four
+saved-view source operations. These operations exchange the complete source
+document so format-aware editors can preserve source data they do not
+interpret.
+
+`read_view_source` accepts a `path` from `list_views` and returns:
+
+```yaml
+path: TaskNotes/Views/tasks.base
+format: obsidian.base
+revision: sha256:opaque
+document: |
+  views:
+    - type: tasknotesTaskList
+      name: Tasks
+```
+
+`create_view_source` accepts `document` and may accept `path`, `format`, and
+`name`. When `path` is absent, the provider selects a collection-relative path
+using the requested format and the collection's format configuration. Creation
+MUST validate the complete document and MUST fail with `path_conflict` rather
+than replace an existing source.
+
+`update_view_source` accepts `path`, `document`, and optional `if_revision`.
+The complete candidate document MUST be valid before the current source is
+atomically replaced. `delete_view_source` accepts `path` and optional
+`if_revision`.
+
+All source operations apply the collection's path-boundary and symlink rules.
+Update and delete use the concurrency behavior defined below. A successful
+create or update returns the same fields as `read_view_source`; a successful
+delete returns `path` and `deleted: true`.
 
 ## Concurrency
 

--- a/15-migrations-and-compatibility.md
+++ b/15-migrations-and-compatibility.md
@@ -110,6 +110,12 @@ the same path-boundary and symlink protections used for record discovery.
 a view-creation interface offers no explicit format. Providers advertising
 write support use these values when creating a source.
 
+Write-capable providers validate the complete `.base` document before a
+source operation commits it. They preserve unknown top-level keys, view keys,
+property metadata, formulas, and presentation options supplied in the
+document. A source editor can therefore modify the structures it understands
+while round-tripping the remainder.
+
 The `.base` file remains authoritative for a discovered Obsidian source.
 `list_views` returns `source.format: obsidian.base`, a revision derived from the
 source bytes, and a stable named-view ID for each contained view. Stable IDs are

--- a/16-conformance.md
+++ b/16-conformance.md
@@ -200,6 +200,18 @@ An implementation advertises `obsidian_bases_views` through
 - returns the saved-view headless result envelope
 - keeps `.base` sources authoritative throughout discovery and execution
 
+An implementation advertises `writable_view_sources` through
+`optional_features` when it:
+
+- marks only writable source formats with `source.writable: true`
+- reads complete source documents with stable opaque revisions
+- validates complete candidate documents before create or update
+- creates sources without replacing an existing path
+- applies `if_revision` to update and delete
+- writes source replacements atomically
+- preserves source-format extension data supplied by the caller
+- makes successful mutations visible to subsequent list and execute operations
+
 Conformance suites for `obsidian_bases_views` MUST include an oracle corpus
 captured from the supported Obsidian expression environment. Each case records
 the expression, evaluation context, expected value or error, and source


### PR DESCRIPTION
## What changed

Defines optional, revision-safe operations for reading, creating, updating, and deleting saved-view source documents. Clarifies atomic validation, writable capability reporting, and conformance requirements.

## Impact

Implementations can expose editable saved views without coupling applications to a storage format or provider.

## Validation

- `python scripts/check_test_levels.py`
- `python scripts/check_v03_tests.py`
- Complete mdbase.dev site build