### PR TITLE
Specify durable runtime execution semantics

### DIFF
--- a/13-runtime-contracts.md
+++ b/13-runtime-contracts.md
@@ -276,6 +276,32 @@ Event IDs MUST be unique within the delivering runtime's deduplication window.
 event or run that directly caused the event. Runtimes MUST preserve both trace
 values when dispatching actions and emitting follow-up events.
 
+### Durable Event Journal
+
+A durable workflow runtime accepts an event by atomically:
+
+1. validating its envelope and payload
+2. reserving `(source.runtime, event.id)` in the deduplication index
+3. assigning a monotonically increasing local cursor
+4. storing the complete envelope at the data authority
+5. admitting all runs derived from that event
+
+The event and its admitted runs become visible together. A crash cannot expose
+the event without its run admissions or run admissions without the event.
+Repeated delivery within the configured replay horizon returns the original
+cursor and MUST NOT create additional runs.
+
+The runtime documents its event retention, deduplication, and cursor-retention
+horizons. A cursor older than retained journal history fails explicitly with
+`event_cursor_expired` or a `reset_required` page; it MUST NOT silently resume
+from the newest event.
+Pruning removes envelopes, not dedupe tombstones, within the documented replay
+horizon. A journal read reports both the retained boundary and current head so
+consumers can distinguish an expired cursor from an empty page.
+Journal payloads remain at the authorized data authority. A routing or
+notification control plane receives only an opaque signal and cursor unless it
+is itself the authorized data authority.
+
 ## Actions And Authorization
 
 ### Action Contract
@@ -306,12 +332,27 @@ effects:
   - mdbase.record.write
 emits:
   - mdbase.record.modified
+dispatch:
+  idempotency: invocation_id
+  cancellation: cooperative
 ```
 
 The action ID resolves to a handler owned by the declared provider. The runtime
 validates evaluated input against `schemas.input` before dispatch and validates
 the returned value against `schemas.output`. Events named by `emits` validate
 before delivery.
+
+`dispatch.idempotency` declares the provider's replay contract:
+
+| Value | Meaning |
+| --- | --- |
+| `invocation_id` | repeated dispatch with the same invocation ID returns the same logical effect and receipt |
+| `none` | the provider makes no safe replay guarantee |
+
+`dispatch.cancellation` is `cooperative` when the provider accepts a runtime
+cancellation request and `none` when an in-flight dispatch cannot be cancelled.
+Omitted dispatch properties have `none` semantics. A runtime MUST NOT infer
+idempotency from an action name, transport, or successful prior response.
 
 ### Capabilities
 
@@ -387,6 +428,38 @@ effects, resource scope, and applicable policy limits. An action with effects
 MUST be denied unless the selected policy explicitly allows every required
 capability. Dispatch also requires a registered handler for the action ID.
 
+An admitted run dispatches against its pinned canonical action contract
+revision. The runtime validates input and output and derives declared effects,
+idempotency, and cancellation from that snapshot; a later registry definition
+MUST NOT silently replace it. Current policy and the host's current exact grant
+are nevertheless re-evaluated immediately before every provider call, so
+authorization can be narrowed or revoked after admission. If the pinned
+provider handler is unavailable, dispatch fails explicitly rather than falling
+back to another action definition.
+
+### Dispatch Identity And Receipts
+
+Every step or iteration item has a stable invocation ID derived before
+dispatch. The runtime persists the invocation ID, action contract revision,
+evaluated input, attempt number, and dispatch intent before calling the
+provider. The provider receives the invocation ID in its dispatch context.
+
+An idempotent provider persists or derives a receipt for the invocation ID and
+returns the same logical result when that invocation is replayed. The runtime
+stores the receipt and validated output before making emitted events visible.
+The result and emitted-event admissions form one durable completion boundary.
+
+If the executor restarts with a dispatch intent but no result:
+
+- an action declaring `dispatch.idempotency: invocation_id` is dispatched again
+  with the same invocation ID
+- an action with `dispatch.idempotency: none` becomes `indeterminate` and is not
+  dispatched automatically
+
+`indeterminate` means that the external effect may have occurred and requires
+provider-specific reconciliation or an explicit operator decision. Arbitrary
+external effects cannot be made exactly once by the runtime alone.
+
 ## Materialization
 
 Materialization writes an implicit contract or runtime state value as a
@@ -413,10 +486,12 @@ Runtimes MAY materialize state using the canonical runtime record schemas:
 | --- | --- |
 | runtime run | one workflow execution attempt, including step results |
 | runtime checkpoint | durable state for waiting or resuming a workflow |
+| runtime timer | one durable, generation-checked, one-shot timer |
 | runtime diagnostic | a validation or execution issue |
 
-Operational run and checkpoint data defaults to `.mdbase/runtime/`. That path
-is excluded from ordinary collection scanning and workflow triggers.
+Operational run, checkpoint, timer, event-journal, and action-receipt data
+defaults to `.mdbase/runtime/`. That path is excluded from ordinary collection
+scanning and workflow triggers.
 
 Runtimes MAY materialize human-significant summaries as ordinary collection
 records. Such records MUST redact secrets, follow the runtime's retention
@@ -429,20 +504,63 @@ Example run:
 type: runtime_run
 id: run_01j0
 workflow: canvas.zone.set-status
-trigger_event: canvas.drop
+workflow_version: 1
+workflow_revision: sha256:7e4b0b28
+registry_revision: sha256:70e5581c
+policy_revision: sha256:4d322612
+trigger: drop
+event_id: evt_01j0
+event_type: canvas.drop
+event_cursor: 42
 executor: desktop
 idempotency_key: canvas.zone.set-status:evt_01j0:drop
 status: succeeded
+created_at: "2026-06-15T08:00:00Z"
 started_at: "2026-06-15T08:00:00Z"
+updated_at: "2026-06-15T08:00:01Z"
 finished_at: "2026-06-15T08:00:01Z"
 steps:
   - id: patch
     action: mdbase.record.patch
+    action_version: 1
+    invocation_id: inv_01j0
+    attempt: 1
     status: succeeded
 ```
 
-Checkpoint records support durable waiting and resumable state. Claim and lease
-coordination uses runtime extensions.
+Every admitted run pins the canonical workflow revision, effective registry
+revision, selected policy revision, and resolved action contract revisions used
+to build it. A registry or policy change affects new admission and
+dispatch-time authorization, but MUST NOT silently rewrite an admitted run's
+plan.
+
+Checkpoint records support durable waiting and resumable state. Checkpoint
+updates use monotonically increasing revisions. A worker claims runnable state
+through a bounded lease containing an owner, opaque token, and expiry. Only the
+current lease token may commit a transition. Expired work can be reclaimed;
+stale workers MUST fail their writes.
+
+### Canonical Timer Provider
+
+Runtime profile 0.1 defines portable one-shot timers. Recurrence is expressed by
+upserting the next one-shot timer after a fire; cron and calendar recurrence are
+provider extensions until separately standardized.
+
+A timer provider supplies:
+
+- `timer.upsert`, keyed by timer ID and replacing the prior generation
+- `timer.cancel`, cancelling a named generation or the current generation
+- `timer.fired`, emitted once for the current generation after `fire_at`
+
+`fire_at` is an RFC 3339 instant. Local timezone and daylight-saving choices are
+resolved by the producer before upsert. Each successful upsert increments the
+timer generation. A claimed stale generation MUST NOT emit.
+
+The portable missed-run policy is `fire_once`: after downtime, the current
+overdue generation fires once with its original scheduled instant and actual
+fire time. Repeated scheduler polling, lease expiry, or restart can redeliver
+the same `timer.fired` event ID but cannot create a second logical fire.
+Cancellation and firing race through one atomic generation transition.
 
 ## Workflow Integration
 
@@ -460,10 +578,10 @@ Runtime profile 0.1 represents adjacent concerns with the following patterns:
 
 | Concern | Profile 0.1 pattern |
 | --- | --- |
-| schedule | event emitted by a timer provider |
+| schedule | canonical one-shot timer provider; recurrence is an extension |
 | approval | checkpoint plus policy or provider action |
 | secret | runtime-managed secret reference value |
-| lease or lock | cooperative runtime extension |
+| distributed lock beyond run/checkpoint leases | cooperative runtime extension |
 | artifact | action output or ordinary file |
 | subscription | workflow trigger |
 

--- a/14-workflows.md
+++ b/14-workflows.md
@@ -75,16 +75,19 @@ For each delivered event, the runtime:
 
 1. validates the event envelope, contract version, provider provenance, and
    payload as defined in Chapter 13
-2. finds enabled workflows with triggers for the event ID
-3. applies trigger debounce and minimum-interval admission
-4. evaluates workflow variables, the trigger condition, and the workflow-level
+2. journals and deduplicates the event at the data authority
+3. finds enabled workflows with triggers for the event ID
+4. applies trigger debounce and minimum-interval admission
+5. evaluates workflow variables, the trigger condition, and the workflow-level
    condition
-5. applies execution-mode and executor policy
-6. derives the idempotency key and concurrency group and admits, queues, skips,
+6. applies execution-mode and executor policy
+7. derives the idempotency key and concurrency group and admits, queues, skips,
    or replaces the run
-7. creates a standard run record and executes steps in document order
-8. validates step outputs and emitted events and records every step result
-9. moves the run to a terminal status
+8. pins a canonical execution plan and atomically commits event and run
+   admission
+9. claims the run with a bounded lease and executes steps in document order
+10. validates step outputs and emitted events and records every step result
+11. moves the run to a terminal status
 
 This sequence is normative. A runtime may combine internal stages while
 preserving their validation, authorization, ordering, and diagnostic outcomes.
@@ -241,6 +244,10 @@ in a store shared by every process using the same executor identity. A prior
 reservation suppresses the duplicate run. The reservation remains valid across
 the provider's documented replay horizon.
 
+The idempotency reservation, concurrency decision, pinned execution plan, and
+run record are committed in the event-admission transaction. Reserving a key
+after dispatch begins is not conformant.
+
 A missing shared reservation store for a side-effecting `single_executor` run
 produces `idempotency_unavailable`. For `broadcast`, reservation scope includes
 the executor identity so each eligible executor can run once.
@@ -276,8 +283,22 @@ can be evaluated.
 
 ## Run And Step Results
 
-A run moves through `queued`, `running`, and one terminal state: `succeeded`,
-`failed`, or `cancelled`.
+A run follows these portable transitions:
+
+| From | To | Cause |
+| --- | --- | --- |
+| admitted | `queued` | concurrency policy delays execution |
+| admitted or `queued` | `running` | a worker obtains the current lease |
+| `running` | `waiting` | a durable checkpoint suspends execution |
+| `waiting` | `queued` | the checkpoint becomes ready |
+| `running` | `succeeded` | every required step completes |
+| `running` | `failed` | a deterministic failure or timeout is recorded |
+| `queued`, `running`, or `waiting` | `cancelled` | cancellation completes without ambiguous effects |
+| `running` | `indeterminate` | a non-idempotent dispatch has an unknown outcome |
+
+`succeeded`, `failed`, `cancelled`, and `indeterminate` are terminal.
+Implementations MUST reject transitions from a terminal state and writes made
+with a stale lease token.
 
 Each step result contains `id`, `action`, and `status`, with `output` or `error`
 when applicable. Step status is one of:
@@ -289,8 +310,10 @@ when applicable. Step status is one of:
 - `skipped`
 - `cancelled`
 - `timed_out`
+- `indeterminate`
 
-A run timeout records the active step as `timed_out` and the run as `failed`.
+A run deadline prevents every not-yet-started dispatch. If no dispatch intent
+is active, the current step is recorded as `timed_out` and the run as `failed`.
 Cancellation records the active step and run as `cancelled`. These outcomes
 remain distinct in diagnostics and run history.
 
@@ -303,6 +326,55 @@ behavior uses an `x-*` extension that defines retry conditions, limits, and
 result history. An action with external effects is retried only when its
 contract declares idempotency support or runtime policy explicitly authorizes
 the retry.
+
+### Durable Action Attempt Protocol
+
+For each step or iteration item, the executor:
+
+1. derives and persists a stable invocation ID
+2. evaluates and validates input
+3. performs current dispatch-time authorization
+4. persists a dispatch intent and attempt number
+5. invokes the provider with the invocation ID
+6. validates output and emitted events
+7. atomically persists the receipt, result, step state, and emitted-event
+   admissions
+
+Provider timeout does not prove that an effect failed. An executor MUST NOT
+erase an active dispatch intent or report a non-idempotent effect as merely
+`timed_out`. If no result is durable, recovery follows the action's declared
+idempotency contract from Chapter 13: an idempotent invocation may be replayed
+with the same invocation ID to reconcile its receipt, while a non-idempotent
+invocation becomes `indeterminate`. Reconciliation never permits a new
+invocation or subsequent workflow step after the run deadline. If an
+idempotent provider returns a committed result after the deadline, the runtime
+records its receipt and effect, marks the step `timed_out`, and fails the run.
+
+### Crash Recovery
+
+On startup and periodically, an executor reclaims expired run and checkpoint
+leases. Recovery resumes from the last committed state:
+
+- pending work can be claimed normally
+- an idempotent dispatch intent is replayed with its original invocation ID
+- a non-idempotent dispatch intent becomes `indeterminate`
+- a committed step result is never dispatched again
+- a committed emitted event can be redelivered but is deduplicated by event ID
+
+Recovery MUST NOT infer success from elapsed time or infer failure from a lost
+transport connection.
+
+### Cancellation And Replacement
+
+Cancellation is durable intent. Queued work can be cancelled immediately.
+Cooperative actions receive a cancellation request; actions declaring
+`dispatch.cancellation: none` are allowed to finish before the run reaches a
+terminal state. Completed effects are never rolled back implicitly.
+
+`replace` records cancellation intent for the active run, waits until that run
+is terminal, and then makes the replacement runnable. If the active run becomes
+`indeterminate`, the replacement remains queued until policy or an operator
+explicitly allows it to proceed.
 
 ## Workflow Sources
 

--- a/16-conformance.md
+++ b/16-conformance.md
@@ -92,7 +92,9 @@ The v0.3 core codes include `unsupported_profile`, `type_conflict`,
 0.1 additionally defines `contract_conflict`, `contract_version_mismatch`,
 `event_provider_mismatch`, `provider_version_mismatch`, `capability_denied`,
 `policy_not_selected`, `executor_not_selected`, and
-`idempotency_unavailable`.
+`idempotency_unavailable`, `event_cursor_expired`, `stale_lease`,
+`invalid_run_transition`, `action_outcome_indeterminate`, and
+`stale_timer_generation`.
 
 ## Core Read Requirements
 
@@ -280,6 +282,7 @@ preflight, and materialization. Workflow execution has its own profile.
 Workflow implementations MUST:
 
 - follow the preflight and event-to-run sequence in Chapter 14
+- atomically journal, deduplicate, and admit delivered events
 - apply trigger debounce and minimum-interval admission
 - evaluate workflow variables and detect dependency cycles
 - evaluate trigger, workflow, and step conditions in their defined contexts
@@ -289,8 +292,16 @@ Workflow implementations MUST:
 - apply execution mode and runtime-policy executor selection
 - reserve idempotency keys with the required executor scope
 - apply concurrency policy, run limits, and `on_error`
-- record standard run and step results
+- pin canonical workflow, registry, action, and policy revisions
+- claim work with bounded leases and reject stale lease writes
+- persist stable invocation IDs and dispatch intents before provider calls
+- recover idempotent attempts and mark ambiguous non-idempotent attempts
+  `indeterminate`
+- record standard run, step, attempt, receipt, and checkpoint results
 - validate action outputs and emitted events
+- commit action results and emitted-event admissions atomically
+- provide generation-safe one-shot timer upsert, cancel, fire, and missed-run
+  behavior when claiming canonical timer support
 - report unsupported actions, capabilities, and unsafe execution state through
   runtime diagnostics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this specification and conformance suite are documented here.
 
+## 2026-07-24 (v0.3.0 runtime RC)
+
+### Added
+
+- Durable event-journal admission, local cursors, and explicit retention
+  behaviour for runtime events.
+- Stable action invocation IDs, provider receipts, dispatch idempotency and
+  cancellation declarations, and honest `indeterminate` outcomes.
+- Portable run and checkpoint leases, pinned execution-plan revisions, and
+  crash-recovery rules.
+- Generation-safe one-shot runtime timers with deterministic `fire_once`
+  missed-run behaviour.
+
+### Changed
+
+- Expanded workflow conformance from in-process execution to durable admission,
+  action attempts, recovery, timer races, and atomic emitted events.
+- Revised the materialized run schema so queued runs no longer require a
+  `started_at` value and all runs expose creation/update and pinned revisions.
+
 ## 2026-07-21 (v0.3.0 draft)
 
 ### Added

--- a/examples/v0.3/canvas-runtime/_types/runtime_timer.md
+++ b/examples/v0.3/canvas-runtime/_types/runtime_timer.md
@@ -1,0 +1,18 @@
+---
+kind: mdbase.type
+name: runtime_timer
+version: 1
+description: Materialized generation-safe one-shot runtime timer.
+
+match:
+  where:
+    type: runtime_timer
+
+schema:
+  dialect: json-schema-2020-12
+  ref: "../../../../schemas/v0.3/runtime/timer.schema.json"
+---
+
+# Runtime Timer
+
+Timer records are optional durable runtime state.

--- a/examples/v0.3/canvas-runtime/actions/mdbase.record.patch.md
+++ b/examples/v0.3/canvas-runtime/actions/mdbase.record.patch.md
@@ -41,6 +41,10 @@ effects:
 emits:
   - mdbase.record.modified
 
+dispatch:
+  idempotency: invocation_id
+  cancellation: cooperative
+
 risk: medium
 ---
 
@@ -48,4 +52,3 @@ risk: medium
 
 This contract describes the portable `mdbase.record.patch` action. The runtime
 still supplies the handler.
-

--- a/notes/SN-101.md
+++ b/notes/SN-101.md
@@ -1,0 +1,44 @@
+---
+id: SN-101
+title: "Durable workflow execution needs explicit crash and timer semantics"
+sections:
+  - "§13 Runtime Contracts"
+  - "§14 Workflows"
+  - "§16 Conformance"
+status: resolved
+kind: gap
+severity: high
+---
+
+**Issue:** Runtime profile 0.1 specified at-least-once event delivery,
+idempotent run admission, concurrency, and result records, but did not define
+the durable boundary around an external action. An executor could crash after
+an effect succeeded and before its result was stored. The profile also treated
+leases and timer behaviour as extensions, leaving recovery and scheduled
+workflows non-portable.
+
+**Resolution:**
+
+1. Events are journalled, deduplicated, assigned local cursors, and admitted
+   atomically with their derived runs.
+2. Admitted runs pin workflow, registry, action, and policy revisions.
+3. Workers claim runs and checkpoints through bounded, token-checked leases.
+4. Every action attempt persists a stable invocation ID and dispatch intent
+   before calling its provider.
+5. Providers explicitly declare invocation-ID idempotency and cooperative
+   cancellation support.
+6. A crash during an idempotent dispatch replays the same invocation. A crash
+   during an unsafe dispatch produces an `indeterminate` terminal result.
+7. Action results, receipts, and emitted-event admissions share a durable
+   completion boundary.
+8. Profile 0.1 standardizes generation-safe one-shot timers with `fire_once`
+   missed-run behaviour. Recurrence is built by scheduling the next one-shot
+   timer; cron/calendar rules remain extensions.
+
+**Rationale:** Exactly-once execution cannot be guaranteed for arbitrary
+external APIs. Stable invocation identity plus explicit indeterminate outcomes
+provides honest, recoverable semantics without hiding ambiguous effects.
+
+**Conformance impact:** Workflow implementations must cover event admission,
+state transitions, stale leases, action-attempt crash recovery, emitted-event
+deduplication, and one-shot timer races.

--- a/packages/runtime-contracts-rs/src/lib.rs
+++ b/packages/runtime-contracts-rs/src/lib.rs
@@ -14,6 +14,7 @@ const RUNTIME_TYPES: &[&str] = &[
     "runtime_policy",
     "runtime_run",
     "runtime_checkpoint",
+    "runtime_timer",
     "runtime_diagnostic",
 ];
 
@@ -57,6 +58,7 @@ pub struct RuntimeSchemas {
     runtime_policy: Value,
     run: Value,
     checkpoint: Value,
+    timer: Value,
     diagnostic: Value,
 }
 
@@ -180,6 +182,7 @@ impl RuntimeSchemas {
             runtime_policy: read_json(schema_root.join("runtime/runtime-policy.schema.json"))?,
             run: read_json(schema_root.join("runtime/run.schema.json"))?,
             checkpoint: read_json(schema_root.join("runtime/checkpoint.schema.json"))?,
+            timer: read_json(schema_root.join("runtime/timer.schema.json"))?,
             diagnostic: read_json(schema_root.join("runtime/diagnostic.schema.json"))?,
         })
     }
@@ -195,6 +198,7 @@ impl RuntimeSchemas {
             ("runtime-policy", &self.runtime_policy),
             ("run", &self.run),
             ("checkpoint", &self.checkpoint),
+            ("timer", &self.timer),
             ("diagnostic", &self.diagnostic),
         ] {
             compile_schema(schema).map_err(|error| format!("{name} schema is invalid: {error}"))?;
@@ -212,6 +216,7 @@ impl RuntimeSchemas {
             "runtime_policy" => Some(&self.runtime_policy),
             "runtime_run" => Some(&self.run),
             "runtime_checkpoint" => Some(&self.checkpoint),
+            "runtime_timer" => Some(&self.timer),
             "runtime_diagnostic" => Some(&self.diagnostic),
             _ => None,
         }
@@ -331,7 +336,7 @@ mod tests {
         .expect("load contracts");
 
         assert_eq!(package.diagnostics, []);
-        assert_eq!(package.type_files.len(), 11);
+        assert_eq!(package.type_files.len(), 12);
         assert_eq!(package.providers.len(), 2);
         assert_eq!(package.actions.len(), 1);
         assert_eq!(package.events.len(), 2);

--- a/packages/runtime-contracts/package-lock.json
+++ b/packages/runtime-contracts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@callumalpass/mdbase-runtime",
-  "version": "0.1.0-rc.2",
+  "version": "0.1.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@callumalpass/mdbase-runtime",
-      "version": "0.1.0-rc.2",
+      "version": "0.1.0-rc.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/packages/runtime-contracts/package.json
+++ b/packages/runtime-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@callumalpass/mdbase-runtime",
-  "version": "0.1.0-rc.2",
+  "version": "0.1.0-rc.3",
   "type": "module",
   "description": "Portable mdbase runtime contracts, provider host, validation, and Node loaders.",
   "license": "MIT",

--- a/packages/runtime-contracts/scripts/generate-schema-module.mjs
+++ b/packages/runtime-contracts/scripts/generate-schema-module.mjs
@@ -20,6 +20,7 @@ const schemaPaths = {
   runtimePolicy: "runtime/runtime-policy.schema.json",
   run: "runtime/run.schema.json",
   checkpoint: "runtime/checkpoint.schema.json",
+  timer: "runtime/timer.schema.json",
   diagnostic: "runtime/diagnostic.schema.json",
   eventEnvelope: "runtime/event-envelope.schema.json",
 };

--- a/packages/runtime-contracts/src/browser.ts
+++ b/packages/runtime-contracts/src/browser.ts
@@ -67,6 +67,7 @@ export type {
   RuntimeRequirements,
   RuntimeRecordType,
   RuntimeRunRecord,
+  RuntimeTimerRecord,
   ValidationResult,
   WorkflowContract,
   WorkflowRunPolicy,

--- a/packages/runtime-contracts/src/canonical-schemas.ts
+++ b/packages/runtime-contracts/src/canonical-schemas.ts
@@ -18,6 +18,7 @@ export interface CanonicalSchemas {
   runtimePolicy: Record<string, unknown>;
   run: Record<string, unknown>;
   checkpoint: Record<string, unknown>;
+  timer: Record<string, unknown>;
   diagnostic: Record<string, unknown>;
   eventEnvelope: Record<string, unknown>;
 }

--- a/packages/runtime-contracts/src/generated-schemas.ts
+++ b/packages/runtime-contracts/src/generated-schemas.ts
@@ -1552,6 +1552,9 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
           "$ref": "#/$defs/identifier"
         }
       },
+      "dispatch": {
+        "$ref": "#/$defs/dispatch"
+      },
       "risk": {
         "enum": [
           "low",
@@ -1573,6 +1576,24 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
       "jsonSchema": {
         "type": "object",
         "additionalProperties": true
+      },
+      "dispatch": {
+        "type": "object",
+        "properties": {
+          "idempotency": {
+            "enum": [
+              "invocation_id",
+              "none"
+            ]
+          },
+          "cancellation": {
+            "enum": [
+              "cooperative",
+              "none"
+            ]
+          }
+        },
+        "additionalProperties": false
       },
       "requires": {
         "type": "object",
@@ -2194,8 +2215,14 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
       "type",
       "id",
       "workflow",
+      "workflow_version",
+      "workflow_revision",
+      "registry_revision",
+      "trigger",
+      "event_id",
       "status",
-      "started_at"
+      "created_at",
+      "updated_at"
     ],
     "properties": {
       "type": {
@@ -2207,8 +2234,31 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
       "workflow": {
         "$ref": "#/$defs/identifier"
       },
-      "trigger_event": {
+      "workflow_version": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "workflow_revision": {
+        "$ref": "#/$defs/revision"
+      },
+      "registry_revision": {
+        "$ref": "#/$defs/revision"
+      },
+      "policy_revision": {
+        "$ref": "#/$defs/revision"
+      },
+      "trigger": {
         "$ref": "#/$defs/identifier"
+      },
+      "event_id": {
+        "$ref": "#/$defs/identifier"
+      },
+      "event_type": {
+        "$ref": "#/$defs/identifier"
+      },
+      "event_cursor": {
+        "type": "integer",
+        "minimum": 1
       },
       "executor": {
         "$ref": "#/$defs/identifier"
@@ -2216,20 +2266,41 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
       "idempotency_key": {
         "type": "string"
       },
+      "concurrency_group": {
+        "type": "string"
+      },
       "status": {
         "enum": [
           "queued",
           "running",
+          "waiting",
           "succeeded",
           "failed",
-          "cancelled"
+          "cancelled",
+          "indeterminate"
         ]
+      },
+      "created_at": {
+        "type": "string",
+        "format": "date-time"
       },
       "started_at": {
         "type": "string",
         "format": "date-time"
       },
+      "timeout_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "updated_at": {
+        "type": "string",
+        "format": "date-time"
+      },
       "finished_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "cancel_requested_at": {
         "type": "string",
         "format": "date-time"
       },
@@ -2249,6 +2320,17 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
             "action": {
               "$ref": "#/$defs/identifier"
             },
+            "action_version": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "invocation_id": {
+              "$ref": "#/$defs/identifier"
+            },
+            "attempt": {
+              "type": "integer",
+              "minimum": 1
+            },
             "status": {
               "enum": [
                 "pending",
@@ -2257,13 +2339,27 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
                 "failed",
                 "skipped",
                 "cancelled",
-                "timed_out"
+                "timed_out",
+                "indeterminate"
               ]
             },
+            "input": {},
             "output": {},
+            "receipt": {
+              "type": "object",
+              "additionalProperties": true
+            },
             "error": {
               "type": "object",
               "additionalProperties": true
+            },
+            "started_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "finished_at": {
+              "type": "string",
+              "format": "date-time"
             }
           },
           "patternProperties": {
@@ -2281,6 +2377,10 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
       "identifier": {
         "type": "string",
         "pattern": "^[A-Za-z][A-Za-z0-9._:-]*$"
+      },
+      "revision": {
+        "type": "string",
+        "minLength": 8
       }
     }
   },
@@ -2330,6 +2430,123 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
       },
       "next_step": {
         "$ref": "#/$defs/identifier"
+      },
+      "revision": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "resume_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "lease": {
+        "type": "object",
+        "required": [
+          "owner",
+          "token",
+          "expires_at"
+        ],
+        "properties": {
+          "owner": {
+            "$ref": "#/$defs/identifier"
+          },
+          "token": {
+            "type": "string",
+            "minLength": 16
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "patternProperties": {
+      "^x-[A-Za-z0-9._:-]+$": true
+    },
+    "additionalProperties": false,
+    "$defs": {
+      "identifier": {
+        "type": "string",
+        "pattern": "^[A-Za-z][A-Za-z0-9._:-]*$"
+      }
+    }
+  },
+  "timer": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://mdbase.dev/schemas/runtime/v0.1/timer.schema.json",
+    "title": "mdbase runtime one-shot timer record",
+    "type": "object",
+    "required": [
+      "type",
+      "id",
+      "generation",
+      "status",
+      "fire_at",
+      "event",
+      "created_at",
+      "updated_at"
+    ],
+    "properties": {
+      "type": {
+        "const": "runtime_timer"
+      },
+      "id": {
+        "$ref": "#/$defs/identifier"
+      },
+      "generation": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "status": {
+        "enum": [
+          "scheduled",
+          "firing",
+          "fired",
+          "cancelled"
+        ]
+      },
+      "fire_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "event": {
+        "type": "object",
+        "required": [
+          "type",
+          "contract_version",
+          "payload"
+        ],
+        "properties": {
+          "type": {
+            "$ref": "#/$defs/identifier"
+          },
+          "contract_version": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "payload": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "missed_run_policy": {
+        "const": "fire_once"
+      },
+      "created_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "updated_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "fired_at": {
+        "type": "string",
+        "format": "date-time"
       }
     },
     "patternProperties": {

--- a/packages/runtime-contracts/src/host.ts
+++ b/packages/runtime-contracts/src/host.ts
@@ -493,6 +493,9 @@ function validateDispatchContext(context: AuthorizationContext): void {
     !context.actor.kind ||
     !context.origin ||
     !context.run_id ||
+    !context.invocation_id ||
+    !Number.isInteger(context.attempt) ||
+    context.attempt < 1 ||
     !context.correlation_id ||
     !context.executor
   ) {

--- a/packages/runtime-contracts/src/index.ts
+++ b/packages/runtime-contracts/src/index.ts
@@ -26,6 +26,7 @@ export type {
   RuntimeLoadResult,
   RuntimeEventEnvelope,
   RuntimeCheckpointRecord,
+  RuntimeTimerRecord,
   RuntimeContractRecord,
   RuntimeDiagnosticRecord,
   RuntimeDiagnostic,

--- a/packages/runtime-contracts/src/schemas.ts
+++ b/packages/runtime-contracts/src/schemas.ts
@@ -41,6 +41,7 @@ export async function loadCanonicalSchemas(schemaRoot?: string): Promise<Canonic
     runtimePolicy: await readJson(join(schemaRoot, "runtime/runtime-policy.schema.json")),
     run: await readJson(join(schemaRoot, "runtime/run.schema.json")),
     checkpoint: await readJson(join(schemaRoot, "runtime/checkpoint.schema.json")),
+    timer: await readJson(join(schemaRoot, "runtime/timer.schema.json")),
     diagnostic: await readJson(join(schemaRoot, "runtime/diagnostic.schema.json")),
     eventEnvelope: await readJson(join(schemaRoot, "runtime/event-envelope.schema.json"))
   };

--- a/packages/runtime-contracts/src/types.ts
+++ b/packages/runtime-contracts/src/types.ts
@@ -7,6 +7,7 @@ export type RuntimeRecordType =
   | "runtime_policy"
   | "runtime_run"
   | "runtime_checkpoint"
+  | "runtime_timer"
   | "runtime_diagnostic";
 
 export type RuntimeSeverity = "info" | "warning" | "error";
@@ -45,6 +46,10 @@ export interface ActionContract extends RuntimeContractRecord {
   requires?: Requires;
   effects?: string[];
   emits?: string[];
+  dispatch?: {
+    idempotency?: "invocation_id" | "none";
+    cancellation?: "cooperative" | "none";
+  };
 }
 
 export interface ProviderContract extends RuntimeContractRecord {
@@ -93,8 +98,19 @@ export interface RuntimePolicyContract extends RuntimeContractRecord {
 export interface RuntimeRunRecord extends RuntimeContractRecord {
   type: "runtime_run";
   workflow: string;
-  status: "queued" | "running" | "succeeded" | "failed" | "cancelled";
-  started_at: string;
+  workflow_version: number;
+  workflow_revision: string;
+  registry_revision: string;
+  policy_revision?: string;
+  trigger: string;
+  event_id: string;
+  event_type?: string;
+  event_cursor?: number;
+  status: "queued" | "running" | "waiting" | "succeeded" | "failed" | "cancelled" | "indeterminate";
+  created_at: string;
+  updated_at: string;
+  started_at?: string;
+  finished_at?: string;
 }
 
 export interface RuntimeCheckpointRecord extends RuntimeContractRecord {
@@ -103,6 +119,22 @@ export interface RuntimeCheckpointRecord extends RuntimeContractRecord {
   status: "open" | "waiting" | "ready" | "completed" | "failed" | "cancelled";
   updated_at: string;
   state: Record<string, unknown>;
+}
+
+export interface RuntimeTimerRecord extends RuntimeContractRecord {
+  type: "runtime_timer";
+  generation: number;
+  status: "scheduled" | "firing" | "fired" | "cancelled";
+  fire_at: string;
+  event: {
+    type: string;
+    contract_version: number;
+    payload: Record<string, unknown>;
+  };
+  missed_run_policy?: "fire_once";
+  created_at: string;
+  updated_at: string;
+  fired_at?: string;
 }
 
 export interface RuntimeDiagnosticRecord extends RuntimeContractRecord {
@@ -190,6 +222,7 @@ export interface RuntimePackage {
   policies: MarkdownRecord<RuntimePolicyContract>[];
   runs: MarkdownRecord<RuntimeRunRecord>[];
   checkpoints: MarkdownRecord<RuntimeCheckpointRecord>[];
+  timers: MarkdownRecord<RuntimeTimerRecord>[];
   runtimeDiagnostics: MarkdownRecord<RuntimeDiagnosticRecord>[];
   diagnostics: RuntimeDiagnostic[];
 }
@@ -247,6 +280,8 @@ export interface AuthorizationContext {
     provider?: string;
   };
   run_id: string;
+  invocation_id: string;
+  attempt: number;
   correlation_id: string;
   causation_id?: string;
   executor: string;

--- a/packages/runtime-contracts/src/validator.ts
+++ b/packages/runtime-contracts/src/validator.ts
@@ -22,6 +22,7 @@ import type {
   RuntimeRecordType,
   RuntimeRegistry,
   RuntimeRunRecord,
+  RuntimeTimerRecord,
   ValidationResult,
   WorkflowContract
 } from "./types.js";
@@ -39,6 +40,7 @@ const runtimeTypes = new Set<RuntimeRecordType>([
   "runtime_policy",
   "runtime_run",
   "runtime_checkpoint",
+  "runtime_timer",
   "runtime_diagnostic"
 ]);
 
@@ -61,6 +63,7 @@ export class RuntimeContractValidator {
       runtime_policy: ajv.compile(schemas.runtimePolicy),
       runtime_run: ajv.compile(schemas.run),
       runtime_checkpoint: ajv.compile(schemas.checkpoint),
+      runtime_timer: ajv.compile(schemas.timer),
       runtime_diagnostic: ajv.compile(schemas.diagnostic),
       eventEnvelope: ajv.compile(schemas.eventEnvelope)
     };
@@ -83,6 +86,7 @@ export class RuntimeContractValidator {
     const policies: MarkdownRecord<RuntimePolicyContract>[] = [];
     const runs: MarkdownRecord<RuntimeRunRecord>[] = [];
     const checkpoints: MarkdownRecord<RuntimeCheckpointRecord>[] = [];
+    const timers: MarkdownRecord<RuntimeTimerRecord>[] = [];
     const runtimeDiagnostics: MarkdownRecord<RuntimeDiagnosticRecord>[] = [];
 
     for (const absolutePath of files) {
@@ -137,6 +141,9 @@ export class RuntimeContractValidator {
         case "runtime_checkpoint":
           checkpoints.push(runtimeRecord as MarkdownRecord<RuntimeCheckpointRecord>);
           break;
+        case "runtime_timer":
+          timers.push(runtimeRecord as MarkdownRecord<RuntimeTimerRecord>);
+          break;
         case "runtime_diagnostic":
           runtimeDiagnostics.push(runtimeRecord as MarkdownRecord<RuntimeDiagnosticRecord>);
           break;
@@ -155,6 +162,7 @@ export class RuntimeContractValidator {
       policies,
       runs,
       checkpoints,
+      timers,
       runtimeDiagnostics,
       diagnostics
     };

--- a/packages/runtime-contracts/test/canvas-runtime.test.mjs
+++ b/packages/runtime-contracts/test/canvas-runtime.test.mjs
@@ -15,7 +15,7 @@ test("loads and preflights the canvas runtime example", async () => {
   const runtimePackage = result.contracts;
 
   assert.deepEqual(runtimePackage.diagnostics, []);
-  assert.equal(runtimePackage.typeFiles.length, 11);
+  assert.equal(runtimePackage.typeFiles.length, 12);
   assert.equal(runtimePackage.providers.length, 2);
   assert.equal(runtimePackage.actions.length, 1);
   assert.equal(runtimePackage.events.length, 2);
@@ -23,6 +23,7 @@ test("loads and preflights the canvas runtime example", async () => {
   assert.equal(runtimePackage.workflows.length, 1);
   assert.equal(runtimePackage.runs.length, 0);
   assert.equal(runtimePackage.checkpoints.length, 0);
+  assert.equal(runtimePackage.timers.length, 0);
   assert.equal(runtimePackage.runtimeDiagnostics.length, 0);
 
   const registry = result.registry;
@@ -85,6 +86,8 @@ test("authorizes effectful actions only through the selected policy", async () =
     actor: { id: "local-user", kind: "user" },
     origin: { workflow: "canvas.zone.set-status" },
     run_id: "run_01",
+    invocation_id: "inv_01",
+    attempt: 1,
     correlation_id: "corr_01",
     causation_id: "evt_01",
     executor: "obsidian"
@@ -247,6 +250,7 @@ test("loads materialized runtime state records outside the executable registry",
   try {
     await mkdir(resolve(root, "runs"), { recursive: true });
     await mkdir(resolve(root, "checkpoints"), { recursive: true });
+    await mkdir(resolve(root, "timers"), { recursive: true });
     await mkdir(resolve(root, "diagnostics"), { recursive: true });
     await writeFile(
       resolve(root, "runs/run_01.md"),
@@ -254,15 +258,26 @@ test("loads materialized runtime state records outside the executable registry",
 type: runtime_run
 id: run_01
 workflow: canvas.zone.set-status
-trigger_event: canvas.drop
+workflow_version: 1
+workflow_revision: sha256:7e4b0b28
+registry_revision: sha256:70e5581c
+policy_revision: sha256:4d322612
+trigger: drop-on-status-zone
+event_id: evt_01
+event_type: canvas.drop
 executor: obsidian
 idempotency_key: canvas.zone.set-status:evt_01:drop
 status: succeeded
+created_at: "2026-06-15T08:00:00Z"
 started_at: "2026-06-15T08:00:00Z"
+updated_at: "2026-06-15T08:00:01Z"
 finished_at: "2026-06-15T08:00:01Z"
 steps:
   - id: patch
     action: mdbase.record.patch
+    action_version: 1
+    invocation_id: inv_01
+    attempt: 1
     status: succeeded
 ---
 `,
@@ -297,12 +312,33 @@ workflow: canvas.zone.set-status
 `,
       "utf8"
     );
+    await writeFile(
+      resolve(root, "timers/timer_01.md"),
+      `---
+type: runtime_timer
+id: timer_01
+generation: 1
+status: scheduled
+fire_at: "2026-06-15T09:00:00Z"
+event:
+  type: timer.fired
+  contract_version: 1
+  payload:
+    subject: task_01
+missed_run_policy: fire_once
+created_at: "2026-06-15T08:00:00Z"
+updated_at: "2026-06-15T08:00:00Z"
+---
+`,
+      "utf8"
+    );
 
     const result = await loadRuntimeContracts(root);
 
     assert.equal(result.contracts.diagnostics.length, 0);
     assert.equal(result.contracts.runs.length, 1);
     assert.equal(result.contracts.checkpoints.length, 1);
+    assert.equal(result.contracts.timers.length, 1);
     assert.equal(result.contracts.runtimeDiagnostics.length, 1);
     assert.equal(result.registry.workflows.size, 0);
   } finally {

--- a/packages/runtime-contracts/test/host.test.mjs
+++ b/packages/runtime-contracts/test/host.test.mjs
@@ -98,6 +98,8 @@ const context = {
   actor: { id: "test", kind: "user" },
   origin: { provider: "test" },
   run_id: "run-1",
+  invocation_id: "invocation-1",
+  attempt: 1,
   correlation_id: "correlation-1",
   executor: "test",
 };

--- a/schemas/v0.3/README.md
+++ b/schemas/v0.3/README.md
@@ -22,6 +22,7 @@ yet published package artifacts.
 | `runtime/runtime-policy.schema.json` | runtime policy records |
 | `runtime/run.schema.json` | materialized run records |
 | `runtime/checkpoint.schema.json` | materialized checkpoint records |
+| `runtime/timer.schema.json` | materialized generation-safe one-shot timers |
 | `runtime/diagnostic.schema.json` | materialized runtime diagnostic records |
 | `runtime/event-envelope.schema.json` | delivered runtime event envelopes |
 

--- a/schemas/v0.3/runtime/action.schema.json
+++ b/schemas/v0.3/runtime/action.schema.json
@@ -65,6 +65,9 @@
         "$ref": "#/$defs/identifier"
       }
     },
+    "dispatch": {
+      "$ref": "#/$defs/dispatch"
+    },
     "risk": {
       "enum": ["low", "medium", "high", "destructive"]
     }
@@ -81,6 +84,18 @@
     "jsonSchema": {
       "type": "object",
       "additionalProperties": true
+    },
+    "dispatch": {
+      "type": "object",
+      "properties": {
+        "idempotency": {
+          "enum": ["invocation_id", "none"]
+        },
+        "cancellation": {
+          "enum": ["cooperative", "none"]
+        }
+      },
+      "additionalProperties": false
     },
     "requires": {
       "type": "object",

--- a/schemas/v0.3/runtime/checkpoint.schema.json
+++ b/schemas/v0.3/runtime/checkpoint.schema.json
@@ -30,6 +30,32 @@
     },
     "next_step": {
       "$ref": "#/$defs/identifier"
+    },
+    "revision": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "resume_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "lease": {
+      "type": "object",
+      "required": ["owner", "token", "expires_at"],
+      "properties": {
+        "owner": {
+          "$ref": "#/$defs/identifier"
+        },
+        "token": {
+          "type": "string",
+          "minLength": 16
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "patternProperties": {

--- a/schemas/v0.3/runtime/run.schema.json
+++ b/schemas/v0.3/runtime/run.schema.json
@@ -3,7 +3,19 @@
   "$id": "https://mdbase.dev/schemas/runtime/v0.1/run.schema.json",
   "title": "mdbase runtime run record",
   "type": "object",
-  "required": ["type", "id", "workflow", "status", "started_at"],
+  "required": [
+    "type",
+    "id",
+    "workflow",
+    "workflow_version",
+    "workflow_revision",
+    "registry_revision",
+    "trigger",
+    "event_id",
+    "status",
+    "created_at",
+    "updated_at"
+  ],
   "properties": {
     "type": {
       "const": "runtime_run"
@@ -14,8 +26,31 @@
     "workflow": {
       "$ref": "#/$defs/identifier"
     },
-    "trigger_event": {
+    "workflow_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "workflow_revision": {
+      "$ref": "#/$defs/revision"
+    },
+    "registry_revision": {
+      "$ref": "#/$defs/revision"
+    },
+    "policy_revision": {
+      "$ref": "#/$defs/revision"
+    },
+    "trigger": {
       "$ref": "#/$defs/identifier"
+    },
+    "event_id": {
+      "$ref": "#/$defs/identifier"
+    },
+    "event_type": {
+      "$ref": "#/$defs/identifier"
+    },
+    "event_cursor": {
+      "type": "integer",
+      "minimum": 1
     },
     "executor": {
       "$ref": "#/$defs/identifier"
@@ -23,14 +58,41 @@
     "idempotency_key": {
       "type": "string"
     },
+    "concurrency_group": {
+      "type": "string"
+    },
     "status": {
-      "enum": ["queued", "running", "succeeded", "failed", "cancelled"]
+      "enum": [
+        "queued",
+        "running",
+        "waiting",
+        "succeeded",
+        "failed",
+        "cancelled",
+        "indeterminate"
+      ]
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
     },
     "started_at": {
       "type": "string",
       "format": "date-time"
     },
+    "timeout_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "finished_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "cancel_requested_at": {
       "type": "string",
       "format": "date-time"
     },
@@ -46,6 +108,17 @@
           "action": {
             "$ref": "#/$defs/identifier"
           },
+          "action_version": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "invocation_id": {
+            "$ref": "#/$defs/identifier"
+          },
+          "attempt": {
+            "type": "integer",
+            "minimum": 1
+          },
           "status": {
             "enum": [
               "pending",
@@ -54,13 +127,27 @@
               "failed",
               "skipped",
               "cancelled",
-              "timed_out"
+              "timed_out",
+              "indeterminate"
             ]
           },
+          "input": {},
           "output": {},
+          "receipt": {
+            "type": "object",
+            "additionalProperties": true
+          },
           "error": {
             "type": "object",
             "additionalProperties": true
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "finished_at": {
+            "type": "string",
+            "format": "date-time"
           }
         },
         "patternProperties": {
@@ -78,6 +165,10 @@
     "identifier": {
       "type": "string",
       "pattern": "^[A-Za-z][A-Za-z0-9._:-]*$"
+    },
+    "revision": {
+      "type": "string",
+      "minLength": 8
     }
   }
 }

--- a/schemas/v0.3/runtime/timer.schema.json
+++ b/schemas/v0.3/runtime/timer.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/runtime/v0.1/timer.schema.json",
+  "title": "mdbase runtime one-shot timer record",
+  "type": "object",
+  "required": [
+    "type",
+    "id",
+    "generation",
+    "status",
+    "fire_at",
+    "event",
+    "created_at",
+    "updated_at"
+  ],
+  "properties": {
+    "type": {
+      "const": "runtime_timer"
+    },
+    "id": {
+      "$ref": "#/$defs/identifier"
+    },
+    "generation": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "status": {
+      "enum": ["scheduled", "firing", "fired", "cancelled"]
+    },
+    "fire_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "event": {
+      "type": "object",
+      "required": ["type", "contract_version", "payload"],
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/identifier"
+        },
+        "contract_version": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "payload": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "missed_run_policy": {
+      "const": "fire_once"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "fired_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "patternProperties": {
+    "^x-[A-Za-z0-9._:-]+$": true
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9._:-]*$"
+    }
+  }
+}

--- a/tests/v0.3/manifest.yaml
+++ b/tests/v0.3/manifest.yaml
@@ -83,11 +83,27 @@ claim_profiles:
   - id: runtime_contracts/0.1
     status: draft
     requires: []
-    requirements: []
+    requirements:
+      - deterministic_registry
+      - strict_contract_validation
+      - event_and_action_schema_validation
+      - provider_registration
+      - policy_preflight
   - id: workflow/0.1
     status: draft
     requires: [runtime_contracts/0.1, cel]
-    requirements: []
+    requirements:
+      - durable_event_admission
+      - trigger_admission
+      - variables_and_conditions
+      - deterministic_steps_and_iteration
+      - dispatch_authorization
+      - execution_modes
+      - idempotency_and_concurrency
+      - run_state_machine
+      - durable_action_attempts
+      - lease_and_crash_recovery
+      - one_shot_timers
   - id: watch
     status: draft
     requires: [core_read]
@@ -139,3 +155,8 @@ fixture_sets:
     coverage_targets: [runtime_contracts/0.1]
     files:
       - runtime-contracts/runtime-contracts.yaml
+  - id: workflow_execution
+    description: durable workflow admission, execution, recovery, cancellation, journals, and timers.
+    coverage_targets: [workflow/0.1]
+    files:
+      - workflow-execution/workflow-execution.yaml

--- a/tests/v0.3/runtime-contracts/runtime-contracts.yaml
+++ b/tests/v0.3/runtime-contracts/runtime-contracts.yaml
@@ -16,7 +16,7 @@ groups:
         expect:
           valid: true
           counts:
-            type_files: 11
+            type_files: 12
             providers: 2
             actions: 1
             events: 2

--- a/tests/v0.3/workflow-execution/workflow-execution.yaml
+++ b/tests/v0.3/workflow-execution/workflow-execution.yaml
@@ -1,0 +1,148 @@
+name: "v0.3 workflow execution and recovery conformance"
+spec_version: "0.3.0"
+fixture_set: workflow_execution
+category: workflow
+spec_ref: "v0.3/13, v0.3/14"
+
+groups:
+  - name: "durable admission and deterministic execution"
+    tests:
+      - id: workflow.atomic-admission
+        name: "event journal and every derived run become visible atomically"
+        covers: [workflow/0.1.durable_event_admission, workflow/0.1.trigger_admission]
+        operation: runtime_admit_event
+        input:
+          event_id: evt_atomic
+          workflows: [first.workflow, second.workflow]
+          failpoint: before_commit
+          retry_after_restart: true
+        expect:
+          before_retry:
+            event_visible: false
+            runs_visible: []
+          after_retry:
+            cursor: 1
+            event_count: 1
+            admitted_workflows: [first.workflow, second.workflow]
+
+      - id: workflow.deterministic-plan
+        name: "variables conditions and iteration are deterministic and bounded"
+        covers: [workflow/0.1.variables_and_conditions, workflow/0.1.deterministic_steps_and_iteration]
+        operation: runtime_execute_event
+        input:
+          event_id: evt_iteration
+          items: [alpha, beta]
+          max_items: 2
+        expect:
+          status: succeeded
+          dispatched_items: [alpha, beta]
+          dispatch_order: document
+
+      - id: workflow.executor-concurrency
+        name: "single executor idempotency and concurrency decisions are shared"
+        covers: [workflow/0.1.execution_modes, workflow/0.1.idempotency_and_concurrency]
+        operation: runtime_race_workers
+        input:
+          workers: 16
+          duplicate_event_deliveries: 16
+          concurrency:
+            group: shared
+            policy: queue
+        expect:
+          event_count: 1
+          run_count: 1
+          concurrent_dispatches: 1
+
+  - name: "authorization attempts and recovery"
+    tests:
+      - id: workflow.dispatch-authorization
+        name: "current policy and host authorization are checked immediately before dispatch"
+        covers: [workflow/0.1.dispatch_authorization]
+        operation: runtime_execute_event
+        input:
+          admit_with_policy: allow
+          change_policy_before_dispatch: deny
+        expect:
+          status: failed
+          error_code: capability_denied
+          provider_calls: 0
+
+      - id: workflow.idempotent-recovery
+        name: "unknown idempotent dispatch reuses its invocation ID after lease recovery"
+        covers: [workflow/0.1.durable_action_attempts, workflow/0.1.lease_and_crash_recovery]
+        operation: runtime_recover_dispatch
+        input:
+          dispatch_idempotency: invocation_id
+          failpoint: after_provider_effect_before_result_commit
+          expire_lease: true
+        expect:
+          status: succeeded
+          logical_effects: 1
+          dispatches: 2
+          same_invocation_id: true
+
+      - id: workflow.non-idempotent-recovery
+        name: "unknown non-idempotent dispatch becomes indeterminate without replay"
+        covers: [workflow/0.1.durable_action_attempts, workflow/0.1.lease_and_crash_recovery]
+        operation: runtime_recover_dispatch
+        input:
+          dispatch_idempotency: none
+          failpoint: after_provider_effect_before_result_commit
+          expire_lease: true
+        expect:
+          status: indeterminate
+          dispatches: 1
+
+      - id: workflow.state-machine
+        name: "terminal transitions and stale lease writes are rejected"
+        covers: [workflow/0.1.run_state_machine]
+        operation: runtime_transition_run
+        input:
+          transitions:
+            - [queued, running]
+            - [running, succeeded]
+            - [succeeded, running]
+          stale_lease_commit: true
+        expect:
+          accepted:
+            - [queued, running]
+            - [running, succeeded]
+          rejected:
+            - transition: [succeeded, running]
+              code: invalid_run_transition
+            - stale_lease_commit: true
+              code: stale_lease
+
+  - name: "timers and retained journals"
+    tests:
+      - id: workflow.one-shot-timer
+        name: "only the current overdue timer generation fires once after restart"
+        covers: [workflow/0.1.one_shot_timers]
+        operation: runtime_fire_timer
+        input:
+          timer_id: reminder
+          generations:
+            - { generation: 1, fire_at: "2026-07-24T00:00:00Z" }
+            - { generation: 2, fire_at: "2026-07-24T00:01:00Z" }
+          restart_at: "2026-07-24T00:02:00Z"
+          scheduler_polls: 3
+        expect:
+          event_type: timer.fired
+          fired_generation: 2
+          logical_events: 1
+          missed_run_policy: fire_once
+
+      - id: workflow.journal-reset
+        name: "pruning keeps dedupe tombstones and reports expired cursors"
+        covers: [workflow/0.1.durable_event_admission]
+        operation: runtime_prune_journal
+        input:
+          deliver_event: evt_retained
+          prune_through: 1
+          redeliver_same_event: true
+          read_after: 0
+        expect:
+          duplicate: true
+          original_cursor: 1
+          reset_required: true
+          retained_after: 1


### PR DESCRIPTION
## Summary
- define atomic event/run admission, durable leases, stable action invocation IDs, crash recovery, cancellation, and honest indeterminate outcomes
- standardize generation-safe one-shot timers and materialized timer/run/checkpoint state
- pin admitted action contracts while rechecking current policy at dispatch
- add runtime schema/package support and workflow recovery conformance fixtures

## Verification
- `python scripts/check_v03_tests.py`
- `python scripts/check_test_levels.py`
- `npm test` in `packages/runtime-contracts`
- `cargo test --manifest-path packages/runtime-contracts-rs/Cargo.toml`
- `npm run build` in `site`