### PR TITLE
Clarify portable record event type membership

### DIFF
--- a/13-runtime-contracts.md
+++ b/13-runtime-contracts.md
@@ -276,6 +276,21 @@ Event IDs MUST be unique within the delivering runtime's deduplication window.
 event or run that directly caused the event. Runtimes MUST preserve both trace
 values when dispatching actions and emitting follow-up events.
 
+### Portable Record Type Membership
+
+Providers that expose the standard `mdbase.record.created`,
+`mdbase.record.modified`, `mdbase.record.renamed`, or
+`mdbase.record.deleted` events use `payload.types` for the record's type
+membership after the change. For deletion, where no record remains,
+`payload.types` is the deleted record's last known membership. Rename and
+modification payloads MAY additionally expose the former membership as
+`payload.previous_types`.
+
+Consumers can therefore select a record type consistently with
+`"<type>" in event.payload.types`, including deletion criteria. They MUST NOT
+require `previous_types` for a deletion event. This naming rule is independent
+of whether a provider includes optional record content in its event contract.
+
 ### Durable Event Journal
 
 A durable workflow runtime accepts an event by atomically:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this specification and conformance suite are documented h
   action attempts, recovery, timer races, and atomic emitted events.
 - Revised the materialized run schema so queued runs no longer require a
   `started_at` value and all runs expose creation/update and pinned revisions.
+- Clarified that standard record-change events always expose post-change, or
+  last-known deletion, type membership through `payload.types`.
 
 ## 2026-07-21 (v0.3.0 draft)
 

--- a/examples/v0.3/canvas-runtime/events/mdbase.record.modified.md
+++ b/examples/v0.3/canvas-runtime/events/mdbase.record.modified.md
@@ -10,11 +10,19 @@ schemas:
   dialect: json-schema-2020-12
   payload:
     type: object
-    required: [path, after]
+    required: [path, types]
     additionalProperties: false
     properties:
       path:
         type: string
+      types:
+        type: array
+        items:
+          type: string
+      previous_types:
+        type: array
+        items:
+          type: string
       before:
         type: object
         additionalProperties: true
@@ -25,9 +33,12 @@ schemas:
         type: array
         items:
           type: string
+      previous_revision:
+        type: string
+      revision:
+        type: string
 ---
 
 # Record modified
 
 Standard event emitted by write-capable runtimes after a record patch.
-


### PR DESCRIPTION
Clarifies that standard record events consistently expose current or last-known deletion membership through payload.types, aligns the runtime example schema, and documents the RC decision in the changelog.