### PR TITLE
Publish privacy policy and service terms

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,13 @@ name: Deploy to GitHub Pages
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
+    paths:
+      - "site/**"
+      - ".github/workflows/deploy.yml"
   workflow_dispatch:
 
 permissions:

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -18,6 +18,7 @@ const ROOT = join(__dirname, '..');
 const DIST = join(__dirname, 'dist');
 const TEMPLATES = join(__dirname, 'templates');
 const STATIC = join(__dirname, 'static');
+const CONTENT = join(__dirname, 'content');
 const STYLE_VERSION = createHash('sha256')
   .update(readFileSync(join(STATIC, 'style.css')))
   .digest('hex')
@@ -79,6 +80,29 @@ const LEGACY_SPEC_FILES = [
   { file: 'v0.2/appendix-b-expression-grammar.md', num: 'B', title: 'Expression Grammar', id: 'appendix-b', group: 'Appendices' },
   { file: 'v0.2/appendix-c-error-codes.md',    num: 'C',  title: 'Error Codes',          id: 'appendix-c', group: 'Appendices' },
   { file: 'v0.2/appendix-d-compatibility.md',  num: 'D',  title: 'Compatibility',        id: 'appendix-d', group: 'Appendices' },
+];
+
+const LEGAL_PAGES = [
+  {
+    source: 'privacy.md',
+    output: 'privacy/index.html',
+    title: 'Privacy Policy',
+    label: 'Privacy',
+    description: 'How mdbase handles account information, service metadata, and collection content.',
+    summary: 'How account information, service metadata, and collection content are handled across the mdbase website and hosted services.',
+    date: 'Effective 25 July 2026',
+    url: 'https://mdbase.dev/privacy/',
+  },
+  {
+    source: 'terms.md',
+    output: 'terms/index.html',
+    title: 'Terms of Service',
+    label: 'Terms',
+    description: 'The terms that apply to the mdbase website and hosted services.',
+    summary: 'The agreement for using mdbase.dev, mdbase connect, hosted collections, and the hosted MCP gateway.',
+    date: 'Effective 25 July 2026',
+    url: 'https://mdbase.dev/terms/',
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -166,6 +190,10 @@ function build() {
   writeFileSync(join(DIST, 'runtime.html'), runtimeHtml);
   console.log('  Built runtime.html');
 
+  for (const page of LEGAL_PAGES) {
+    buildLegalPage(page);
+  }
+
   // Build spec page
   buildSpec({
     entries: SPEC_FILES,
@@ -183,6 +211,25 @@ function build() {
   });
 
   console.log('\nDone! Output in site/dist/');
+}
+
+function buildLegalPage(page) {
+  const template = versionAssets(readFileSync(join(TEMPLATES, 'legal.html'), 'utf-8'));
+  const markdown = readFileSync(join(CONTENT, page.source), 'utf-8');
+  const content = marked.parse(markdown);
+  const rendered = template
+    .replaceAll('{{PAGE_TITLE}}', page.title)
+    .replace('{{PAGE_LABEL}}', page.label)
+    .replaceAll('{{PAGE_DESCRIPTION}}', page.description)
+    .replace('{{PAGE_SUMMARY}}', page.summary)
+    .replace('{{PAGE_DATE}}', page.date)
+    .replaceAll('{{PAGE_URL}}', page.url)
+    .replace('{{PAGE_CONTENT}}', content);
+  const outputPath = join(DIST, page.output);
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, rendered);
+  console.log(`  Built ${page.output}`);
 }
 
 function buildSpec({ entries, output: outputFile, title, version, switchLink }) {

--- a/site/content/privacy.md
+++ b/site/content/privacy.md
@@ -1,0 +1,212 @@
+## About this policy
+
+This Privacy Policy explains how Callum Alpass, operating mdbase ("mdbase",
+"we", "us"), handles personal information when you visit mdbase.dev or use
+mdbase services, including mdbase connect and the hosted MCP gateway.
+
+This policy applies to the services operated by mdbase. Third-party
+applications that you connect to a collection have their own privacy practices.
+
+## The short version
+
+- We do not sell personal information or use collection content for advertising
+  or to train artificial intelligence models.
+- The public mdbase.dev website does not currently use advertising cookies or
+  analytics.
+- Local collection paths and record content stay on your computer unless you
+  choose to host, sync, or disclose that content to an authorised application.
+- Relayed local collection operations are end-to-end encrypted. The Connect
+  control plane sees routing metadata and ciphertext, not record content.
+- Hosted collection content is encrypted at rest, but the hosted provider can
+  decrypt it to perform the queries, validation, storage, and synchronisation
+  you request.
+
+## Information we collect
+
+### Account and sign-in information
+
+When you create or use an account, we receive information from the identity
+provider you choose, such as:
+
+- your name, email address, username, and profile image;
+- the provider's stable account identifier;
+- whether the provider has verified your email address; and
+- sign-in times, session information, and authentication events.
+
+We do not receive or store your Google or GitHub password. Google sign-in is
+used only for basic identity; mdbase does not request Google Drive, Gmail, or
+other Google product access as part of account sign-in.
+
+### Computers, collections, applications, and grants
+
+To operate Connect, we store service metadata such as:
+
+- account, computer, connector, collection, application, replica, and grant
+  identifiers;
+- names you give computers and collections;
+- collection specification versions and declared contract or type metadata;
+- applications you connect, the permissions you approve, and revocation state;
+- connection state, last-seen times, synchronisation cursors, and operational
+  events; and
+- notification subscriptions and delivery state if you enable notifications.
+
+For a local collection, the Connect control plane does not receive the local
+filesystem path.
+
+### Collection operations and content
+
+How content is handled depends on the storage mode you choose:
+
+- **Local collection:** canonical Markdown remains on your computer. An
+  authorised application can receive only the operations and records allowed by
+  the grant you approve.
+- **Encrypted relay:** the control plane routes end-to-end encrypted operation
+  payloads between an authorised application and your connector. It can observe
+  identifiers, operation type, timing, approximate sizes, connection state, and
+  routing outcomes, but cannot read the encrypted request or response.
+- **Hosted collection:** canonical Markdown and retained versions are stored
+  encrypted at rest. The hosted provider can decrypt content in memory to
+  validate, query, update, and synchronise the collection. Authorised
+  applications and replicas receive content within their approved scope.
+- **Hosted MCP gateway:** when you explicitly connect an MCP host, the gateway
+  decrypts authorised responses in memory so it can return them to that host.
+  It is designed not to persist record payloads, local paths, or operation
+  results.
+
+Markdown can contain personal or sensitive information. You decide what to put
+in a collection and which applications may access it.
+
+### Technical and support information
+
+When you use the services, our infrastructure may process:
+
+- IP address, browser or client type, request time, response status, and
+  security or rate-limit events;
+- crash reports, diagnostics, and service logs that we generate or that you
+  choose to send; and
+- messages and attachments you send when requesting support.
+
+The mdbase.dev website loads its typefaces from Google Fonts, so your browser
+may make a request to Google when loading a page.
+
+## How we use information
+
+We use information to:
+
+- provide accounts, authentication, hosting, synchronisation, relaying, MCP
+  access, and notifications;
+- apply the permissions you approve and enforce revocation;
+- secure the services, prevent abuse, investigate faults, and maintain
+  reliability;
+- respond to support requests and communicate important service or policy
+  changes;
+- understand aggregate service capacity and improve functionality; and
+- comply with legal obligations and protect users, mdbase, and others.
+
+Where applicable law requires a legal basis, we rely on performing our
+agreement with you, our legitimate interests in operating and securing the
+services, your consent, and compliance with law.
+
+## When we disclose information
+
+We disclose information only as needed for the following purposes:
+
+- **Infrastructure providers.** Current providers include GitHub Pages for the
+  public website, Cloudflare for network and security services, and Render for
+  application and database hosting.
+- **Identity providers.** Google or GitHub processes sign-in information when
+  you choose that provider.
+- **Applications and MCP hosts you authorise.** These parties receive collection
+  information within the permissions you approve. Their own terms and privacy
+  policies apply after they receive it.
+- **Notification services.** Browser or platform push providers process the
+  delivery information needed to send notifications you enable.
+- **Professional advisers and authorities.** We may disclose information when
+  reasonably necessary to obtain professional advice, comply with law, respond
+  to valid legal process, or protect rights, safety, and service integrity.
+- **A business transfer.** If responsibility for mdbase changes, information
+  may transfer with the service, subject to this policy and applicable law.
+
+We do not sell or rent personal information.
+
+## Data locations and international processing
+
+mdbase is operated from Australia. Production Connect services and databases
+are currently hosted in Singapore. Infrastructure, identity, and application
+providers may process information in Australia, Singapore, the United States,
+and other countries where they operate.
+
+Those countries may have different privacy laws. We use service providers and
+technical protections intended to keep information appropriately protected
+when it is processed outside Australia.
+
+## Security
+
+We use safeguards appropriate to the service, including encrypted transport,
+hashed cloud credentials, scoped grants, short-lived authorisation state,
+encryption at rest for hosted content, end-to-end encryption for relay
+payloads, access controls, rate limits, and audit metadata.
+
+No online system is completely secure. Keep your identity-provider account and
+devices secure, install updates, review application grants, revoke access you
+no longer need, and keep an independent backup of important Markdown.
+
+## Retention and deletion
+
+We retain account and service metadata while your account is active and for as
+long as reasonably needed to operate, secure, and meet legal obligations.
+Authentication state and sessions expire. Operational and security records may
+be retained after other account data when reasonably required to investigate
+abuse, maintain integrity, or comply with law.
+
+Deleting a hosted collection removes it from active service storage. Copies may
+remain temporarily in encrypted backups until those backups are overwritten.
+Revoking an application or replica stops future access but does not control
+copies that a third party lawfully received before revocation.
+
+To request account deletion, contact
+[support@mdbase.dev](mailto:support@mdbase.dev). We may need to verify your
+identity before completing a request.
+
+## Your choices and rights
+
+You can:
+
+- review and revoke application grants through Connect;
+- remove computers, replicas, and hosted collections;
+- sign out and stop using the services;
+- choose whether to enable notifications; and
+- request access to, correction of, or deletion of your personal information.
+
+Depending on where you live, you may also have rights to object, restrict
+processing, or receive a portable copy of information. Contact us to make a
+request. You may also complain to your local privacy regulator, including the
+Office of the Australian Information Commissioner where applicable.
+
+## Cookies and local storage
+
+Connect uses secure cookies that are necessary for sign-in, session management,
+and protection of authentication flows. The public website stores a theme
+preference in your browser when you select System, Light, or Dark.
+
+We do not currently use advertising cookies or third-party analytics on
+mdbase.dev. If that changes, we will update this policy and provide any choices
+required by law.
+
+## Children
+
+The hosted services are intended for adults and are not directed to children.
+Do not create an account if you are under 18.
+
+## Changes to this policy
+
+We may update this policy as the services or legal requirements change. We will
+publish the revised policy here, update the date, and provide reasonable notice
+of material changes where practical.
+
+## Contact and complaints
+
+Questions, privacy requests, and complaints can be sent to
+[support@mdbase.dev](mailto:support@mdbase.dev). Please describe your concern
+and how we can contact you. We will review it and respond within a reasonable
+period.

--- a/site/content/terms.md
+++ b/site/content/terms.md
@@ -1,0 +1,226 @@
+## About these terms
+
+These Terms of Service ("Terms") are an agreement between you and Callum
+Alpass, operating mdbase ("mdbase", "we", "us"). They apply when you use
+mdbase.dev and hosted mdbase services, including mdbase connect and the hosted
+MCP gateway.
+
+By creating an account or using a hosted service, you agree to these Terms. If
+you do not agree, do not create an account or use the hosted services.
+
+## The short version
+
+- You keep ownership of your Markdown and other content.
+- You give mdbase only the permission needed to host, process, transmit, and
+  back up content while providing the service you choose.
+- Local content stays on your devices unless you choose to host, sync, or share
+  it with an authorised application.
+- Review grants carefully and keep independent backups of important content.
+- Do not use the service to harm others, break the law, or interfere with the
+  service.
+- The hosted service is an early release and may change, but these Terms do not
+  exclude rights that cannot lawfully be excluded.
+
+This summary is provided for convenience. The complete Terms below govern.
+
+## 1. Eligibility and accounts
+
+You must be at least 18 and legally capable of entering this agreement. You
+must provide accurate account information and use an identity-provider account
+that you are authorised to use.
+
+You are responsible for activity under your account, the security of your
+identity-provider account and devices, and promptly notifying us if you believe
+your account or a connector credential has been compromised.
+
+## 2. The services
+
+mdbase provides:
+
+- a public specification and implementation resources for typed Markdown
+  collections;
+- software that connects user-approved applications to local or hosted
+  collections;
+- encrypted relay, hosted collection, synchronisation, notification, and
+  account services; and
+- a hosted MCP gateway for connections you expressly authorise.
+
+The features available to you may change as the service develops. We will use
+reasonable care and skill in operating the hosted services.
+
+## 3. Open-source software and specification materials
+
+Open-source software, specifications, schemas, examples, and other repository
+materials are licensed under the licence identified with those materials. Those
+licences govern your use of the relevant materials. These Terms govern the
+websites and hosted services and do not replace an applicable open-source
+licence.
+
+Except for rights granted under an identified licence, mdbase and its licensors
+retain their rights in the services, branding, website, and documentation.
+
+## 4. Your content
+
+You retain ownership of content you store, synchronise, or transmit through the
+services.
+
+You give mdbase a limited, non-exclusive licence to host, copy, transmit,
+decrypt where the selected service requires it, process, and back up your
+content only to:
+
+- provide the features you request;
+- maintain, secure, troubleshoot, and restore the services; and
+- comply with law and enforce these Terms.
+
+This licence lasts only for as long as reasonably necessary for those purposes.
+It does not permit us to sell your content, use it for advertising, or use it
+to train artificial intelligence models.
+
+You must have the rights needed to place content in the service and to permit
+the processing described in these Terms. Do not use the service to store or
+share content unlawfully.
+
+## 5. Local collections, hosted collections, and connected applications
+
+For local collections, canonical Markdown remains on your computer. Connect may
+route encrypted operations to your connector and store the service metadata
+needed to apply grants.
+
+For hosted collections, mdbase stores and processes the canonical Markdown.
+Hosted content is encrypted at rest, but the hosted provider can decrypt it to
+perform authorised collection operations.
+
+Applications and MCP hosts are given only the scope you approve through
+Connect. You are responsible for reviewing an application's identity and
+requested permissions. Revocation stops future access through mdbase but cannot
+recall content that an application lawfully received before revocation.
+Third-party applications are responsible for their own conduct, terms, and
+privacy practices.
+
+## 6. Acceptable use
+
+You must not use the services to:
+
+- violate law or another person's rights, including privacy, intellectual
+  property, confidentiality, or data-protection rights;
+- upload or distribute malware, exploit code intended to harm others, or
+  content used for fraud, phishing, harassment, or abuse;
+- gain unauthorised access to an account, device, collection, application, or
+  network;
+- bypass grants, security controls, rate limits, or service restrictions;
+- materially disrupt, overload, probe, or test the services without written
+  permission, except for good-faith reporting of a vulnerability; or
+- enable another person to do any of those things.
+
+If you discover a security issue, report it to
+[support@mdbase.dev](mailto:support@mdbase.dev) and avoid accessing or changing
+other users' information.
+
+## 7. Backups and data management
+
+Hosted services include operational backups, but they are not a substitute for
+your own backup. Keep an independent copy of important content. You can export
+a hosted collection by synchronising it to an ordinary Markdown folder.
+
+Deletion of a hosted collection is intended to be permanent and may not be
+recoverable from the service. Before deleting content or changing an
+authoritative replica, confirm that you have the copy you need.
+
+## 8. Availability and service changes
+
+The hosted services are an early release. Interruptions, faults, and breaking
+changes may occur. We do not promise uninterrupted availability or a service
+level unless we agree one with you separately.
+
+We may add, remove, or change features to improve security, comply with law, or
+develop the service. Where a change materially reduces a hosted feature you
+reasonably rely on, we will provide reasonable notice where practical and allow
+you to stop using the affected service and export your hosted content.
+
+## 9. Fees
+
+Some services are currently offered without charge. We may introduce paid
+plans or usage limits in the future, but we will disclose the price and
+applicable terms before charging you. We will not charge you merely because you
+used a previously free service.
+
+## 10. Suspension and termination
+
+You may stop using the services at any time. You can delete hosted collections
+through Connect and can request account deletion by contacting
+[support@mdbase.dev](mailto:support@mdbase.dev).
+
+We may restrict or suspend access when reasonably necessary to:
+
+- address a security risk or service emergency;
+- prevent unlawful, abusive, or materially disruptive use;
+- comply with law or a binding direction; or
+- respond to a material breach of these Terms.
+
+Where practical, we will provide notice, explain the reason, and give you a
+reasonable opportunity to remedy a breach. We may act immediately where delay
+would create material risk. When an account ends, we will handle retained
+information as described in the Privacy Policy.
+
+## 11. Privacy
+
+Our [Privacy Policy](/privacy/) explains how we handle personal information and
+collection content. By using the services, you acknowledge those practices.
+
+## 12. Consumer rights and warranties
+
+Nothing in these Terms excludes, restricts, or modifies a guarantee, right, or
+remedy that cannot lawfully be excluded, including rights that may apply under
+the Australian Consumer Law.
+
+Subject to those rights, the services are provided on an "as available" basis.
+We do not promise that every feature will be error-free, continuously
+available, or suitable for a purpose that we have not expressly agreed to.
+
+## 13. Liability
+
+Nothing in this section limits liability where doing so would be unlawful,
+including liability for fraud, wilful misconduct, personal injury caused by
+negligence, or a non-excludable consumer guarantee.
+
+To the maximum extent permitted by law:
+
+- neither party is liable to the other for indirect or consequential loss that
+  was not reasonably foreseeable when these Terms were accepted; and
+- mdbase's aggregate liability arising from the hosted services is limited to
+  the greater of AUD 100 and the amount you paid mdbase for those services
+  during the 12 months before the event giving rise to the claim.
+
+This allocation reflects the early-stage nature and current price of the
+service. It does not reduce any remedy you have under applicable law.
+
+## 14. Changes to these Terms
+
+We may update these Terms as the services or legal requirements change. We will
+publish the revised Terms and update the effective date. We will provide
+reasonable notice of material changes where practical.
+
+Changes apply prospectively. If you do not agree to a material change, you may
+stop using the hosted services and request deletion before the change takes
+effect.
+
+## 15. Governing law
+
+These Terms are governed by the laws of Victoria, Australia. The courts of
+Victoria have non-exclusive jurisdiction. This does not prevent a consumer
+from relying on mandatory rights or bringing a claim in another forum available
+under applicable law.
+
+## 16. General
+
+If part of these Terms is unenforceable, the remaining terms continue to
+apply. A delay in enforcing a right is not a waiver of that right.
+
+These Terms, the Privacy Policy, and any service-specific terms presented to
+you form the agreement for the hosted services. An applicable open-source
+licence remains separate.
+
+## 17. Contact
+
+Questions about these Terms can be sent to
+[support@mdbase.dev](mailto:support@mdbase.dev).

--- a/site/static/style.css
+++ b/site/static/style.css
@@ -904,6 +904,61 @@ td {
   font-size: 0.76rem;
 }
 
+/* Legal pages */
+
+.legal-page {
+  width: min(var(--page), 100%);
+  margin: 0 auto;
+  padding: calc(var(--header) + 5rem) var(--space-xl) 7rem;
+}
+
+.legal-page-header {
+  max-width: var(--measure);
+  margin-bottom: var(--space-3xl);
+  padding-bottom: var(--space-2xl);
+  border-bottom: 1px solid var(--line);
+}
+
+.legal-page-header h1 {
+  max-width: 14ch;
+  margin: var(--space-md) 0 var(--space-lg);
+  font-size: clamp(2.8rem, 7vw, 5rem);
+  letter-spacing: -0.04em;
+}
+
+.legal-page-summary {
+  max-width: 44rem;
+  color: var(--ink-soft);
+  font-size: 1.15rem;
+  line-height: 1.58;
+}
+
+.legal-page-date {
+  margin: var(--space-lg) 0 0;
+  color: var(--ink-muted);
+  font-family: var(--mono);
+  font-size: 0.7rem;
+}
+
+.legal-content {
+  max-width: var(--measure);
+}
+
+.legal-content > h2:first-child {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
+}
+
+.legal-content h2,
+.legal-content h3 {
+  scroll-margin-top: calc(var(--header) + var(--space-xl));
+}
+
+.legal-content .anchor {
+  display: none;
+}
+
 /* Footer */
 
 .landing-footer {
@@ -1036,6 +1091,14 @@ td {
 
   .eco-section {
     padding: var(--space-2xl) var(--space-lg) var(--space-3xl);
+  }
+
+  .legal-page {
+    padding: calc(var(--header) + 4rem) var(--space-lg) 5rem;
+  }
+
+  .legal-page-header {
+    margin-bottom: var(--space-2xl);
   }
 
   .eco-section-header {

--- a/site/templates/ecosystem.html
+++ b/site/templates/ecosystem.html
@@ -125,7 +125,7 @@
   </main>
 
   <footer class="landing-footer">
-    <p>mdbase specification v0.3.0 &middot; <a href="spec-v0.2.html">v0.2 archive</a> &middot; <a href="https://opensource.org/licenses/MIT">MIT License</a> &middot; <a href="https://github.com/callumalpass/mdbase-spec">Source on GitHub</a></p>
+    <p>mdbase specification v0.3.0 &middot; <a href="spec-v0.2.html">v0.2 archive</a> &middot; <a href="/privacy/">Privacy</a> &middot; <a href="/terms/">Terms</a> &middot; <a href="https://opensource.org/licenses/MIT">MIT License</a> &middot; <a href="https://github.com/callumalpass/mdbase-spec">Source on GitHub</a></p>
   </footer>
 
 </body>

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -47,7 +47,7 @@
   </main>
 
   <footer class="landing-footer">
-    <p>mdbase specification v0.3.0 &middot; <a href="spec-v0.2.html">v0.2 archive</a> &middot; <a href="https://opensource.org/licenses/MIT">MIT License</a> &middot; <a href="https://github.com/callumalpass/mdbase-spec">Source on GitHub</a></p>
+    <p>mdbase specification v0.3.0 &middot; <a href="spec-v0.2.html">v0.2 archive</a> &middot; <a href="/privacy/">Privacy</a> &middot; <a href="/terms/">Terms</a> &middot; <a href="https://opensource.org/licenses/MIT">MIT License</a> &middot; <a href="https://github.com/callumalpass/mdbase-spec">Source on GitHub</a></p>
   </footer>
 </body>
 </html>

--- a/site/templates/legal.html
+++ b/site/templates/legal.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{PAGE_TITLE}} - mdbase</title>
+  <meta name="description" content="{{PAGE_DESCRIPTION}}">
+  <meta property="og:title" content="{{PAGE_TITLE}} - mdbase">
+  <meta property="og:description" content="{{PAGE_DESCRIPTION}}">
+  <meta property="og:url" content="{{PAGE_URL}}">
+  <meta property="og:type" content="website">
+  <meta name="theme-color" content="#fdfdfd">
+  <link rel="canonical" href="{{PAGE_URL}}">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9670;</text></svg>">
+  <script src="/theme.js"></script>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body class="site-page legal-site-page">
+  <header class="landing-header">
+    <a href="/" class="landing-logo"><span class="dot"></span>mdbase</a>
+    <nav class="landing-nav" aria-label="Primary">
+      <a href="/">Home</a>
+      <a href="/runtime.html">Runtime</a>
+      <a href="/ecosystem.html">Ecosystem</a>
+      <select class="theme-select" aria-label="Color theme" data-theme-select><option value="system">System</option><option value="light">Light</option><option value="dark">Dark</option></select>
+      <a href="/spec.html" class="nav-cta">Read the spec</a>
+    </nav>
+  </header>
+
+  <main>
+    <article class="legal-page">
+      <header class="legal-page-header">
+        <p class="section-kicker">Legal / {{PAGE_LABEL}}</p>
+        <h1>{{PAGE_TITLE}}</h1>
+        <p class="legal-page-summary">{{PAGE_SUMMARY}}</p>
+        <p class="legal-page-date">{{PAGE_DATE}}</p>
+      </header>
+      <div class="legal-content">
+        {{PAGE_CONTENT}}
+      </div>
+    </article>
+  </main>
+
+  <footer class="landing-footer">
+    <p>mdbase &middot; <a href="/privacy/">Privacy</a> &middot; <a href="/terms/">Terms</a> &middot; <a href="https://github.com/callumalpass/mdbase-spec">Source on GitHub</a></p>
+  </footer>
+</body>
+</html>

--- a/site/templates/runtime.html
+++ b/site/templates/runtime.html
@@ -123,7 +123,7 @@ steps:
   </main>
 
   <footer class="landing-footer">
-    <p>mdbase specification v0.3.0 &middot; runtime profile 0.1 &middot; <a href="spec-v0.2.html">v0.2 archive</a> &middot; <a href="https://opensource.org/licenses/MIT">MIT License</a> &middot; <a href="https://github.com/callumalpass/mdbase-spec">Source on GitHub</a></p>
+    <p>mdbase specification v0.3.0 &middot; runtime profile 0.1 &middot; <a href="spec-v0.2.html">v0.2 archive</a> &middot; <a href="/privacy/">Privacy</a> &middot; <a href="/terms/">Terms</a> &middot; <a href="https://opensource.org/licenses/MIT">MIT License</a> &middot; <a href="https://github.com/callumalpass/mdbase-spec">Source on GitHub</a></p>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
## What changed

- add plain-language Privacy Policy and Terms of Service pages for mdbase.dev and hosted mdbase services
- describe the actual local, relay, hosted collection, and MCP trust boundaries
- link both documents from the public site footer
- generate `/privacy/` and `/terms/` through the existing static-site build
- deploy site-only changes automatically when they merge to `main`

## Why

Google authentication and the upcoming public launch need a public privacy policy, user-support path, and service terms. Keeping the documents in the site source ensures normal deployments cannot omit them.

## User impact

Visitors can review canonical legal pages at `https://mdbase.dev/privacy/` and `https://mdbase.dev/terms/`. The terms preserve user ownership of collection content, distinguish open-source licences from hosted-service terms, and retain non-excludable consumer rights.

## Validation

- `npm ci`
- `npm run build`
- desktop render of the Privacy Policy
- mobile render of the Terms of Service
- local HTTP checks for `/privacy`, `/privacy/`, `/terms`, `/terms/`, and versioned assets
- `git diff --check`