### PR TITLE
Clarify privacy provider relationships

### DIFF
--- a/site/content/privacy.md
+++ b/site/content/privacy.md
@@ -111,9 +111,11 @@ services, your consent, and compliance with law.
 
 We disclose information only as needed for the following purposes:
 
-- **Infrastructure providers.** Current providers include GitHub Pages for the
-  public website, Cloudflare for network and security services, and Render for
-  application and database hosting.
+- **Infrastructure providers.** GitHub Pages hosts the public website, and
+  Render hosts the application services and database. These providers may use
+  their own infrastructure and subprocessors to deliver their services. For
+  example, Render currently delivers some mdbase traffic through Cloudflare
+  network infrastructure; mdbase does not contract with Cloudflare directly.
 - **Identity providers.** Google or GitHub processes sign-in information when
   you choose that provider.
 - **Applications and MCP hosts you authorise.** These parties receive collection


### PR DESCRIPTION
## What changed

Clarifies the privacy policy's infrastructure-provider disclosure:

- identifies GitHub Pages and Render as mdbase's direct hosting providers
- explains that those providers may use their own infrastructure and subprocessors
- identifies Cloudflare as part of Render's current delivery path, not a provider contracted by mdbase directly

## Why

The previous wording incorrectly implied that mdbase had a direct Cloudflare provider relationship.

## Validation

- `git diff --check`
- `npm run build` in `site/`