### PR TITLE
Adopt the Frontmatter identity on mdbase.dev

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -137,13 +137,24 @@ Atkinson Hyperlegible provides clarity across large headlines and long specifica
 
 Use the sans face for prose and hierarchy. Reserve mono for structural information and literal technical content.
 
-## 4. Layout and elevation
+## 4. Identity
+
+The shared mdbase Frontmatter mark precedes the live-type `mdbase` wordmark in
+every site header. Its segmented fences and key-value rows connect the
+specification identity directly to the files it defines. Ink follows the
+current theme; the first value uses the blue accent.
+
+Render the mark at 20px in site navigation. It identifies mdbase only and does
+not replace version, conformance, or runtime-profile labels. Use the dedicated
+favicon asset for browser metadata.
+
+## 5. Layout and elevation
 
 The system is flat. One-pixel rules establish sections, rows, navigation boundaries, and code surfaces. Page content uses a 64rem maximum width. Landing sections add an 8rem metadata gutter on wide screens, then collapse to a single column below 64rem.
 
 Whitespace carries hierarchy at page scale. Within resource lists and the specification reader, spacing becomes denser to support scanning.
 
-## 5. Components
+## 6. Components
 
 - **Primary button:** current surface, quiet neutral border, ink text, 3px radius, 44px minimum height.
 - **Secondary button:** the same light structure with quieter border emphasis.
@@ -152,7 +163,7 @@ Whitespace carries hierarchy at page scale. Within resource lists and the specif
 - **Spec sidebar link:** blue text with a quiet underline for the selected section.
 - **Tablist:** text labels with a blue underline for the selected tab and keyboard arrow support.
 
-## 6. Usage principles
+## 7. Usage principles
 
 - Lead pages with literal descriptions of the specification or runtime profile.
 - Show real collection structures, type definitions, records, and queries.

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -27,11 +27,30 @@ const THEME_VERSION = createHash('sha256')
   .update(readFileSync(join(STATIC, 'theme.js')))
   .digest('hex')
   .slice(0, 12);
+const MDBASE_MARK = `<svg class="mdbase-mark" viewBox="18 18 84 84" aria-hidden="true" focusable="false">
+  <g class="mdbase-mark-ink">
+    <rect x="22" y="22" width="20" height="10" rx="2"/>
+    <rect x="50" y="22" width="20" height="10" rx="2"/>
+    <rect x="78" y="22" width="20" height="10" rx="2"/>
+    <rect x="22" y="44" width="12" height="10" rx="2"/>
+    <rect x="22" y="66" width="28" height="10" rx="2"/>
+    <rect x="58" y="66" width="40" height="10" rx="2"/>
+    <rect x="22" y="88" width="20" height="10" rx="2"/>
+    <rect x="50" y="88" width="20" height="10" rx="2"/>
+    <rect x="78" y="88" width="20" height="10" rx="2"/>
+  </g>
+  <rect class="mdbase-mark-accent" x="42" y="44" width="56" height="10" rx="2"/>
+</svg>`;
 
 function versionAssets(html) {
   return html
     .replaceAll('style.css', `style.css?v=${STYLE_VERSION}`)
     .replaceAll('theme.js', `theme.js?v=${THEME_VERSION}`);
+}
+
+function renderTemplate(name) {
+  return versionAssets(readFileSync(join(TEMPLATES, name), 'utf-8'))
+    .replaceAll('{{MDBASE_MARK}}', MDBASE_MARK);
 }
 
 // ---------------------------------------------------------------------------
@@ -176,17 +195,17 @@ function build() {
   console.log('  Copied static assets');
 
   // Copy index.html
-  const indexHtml = versionAssets(readFileSync(join(TEMPLATES, 'index.html'), 'utf-8'));
+  const indexHtml = renderTemplate('index.html');
   writeFileSync(join(DIST, 'index.html'), indexHtml);
   console.log('  Built index.html');
 
   // Copy ecosystem.html
-  const ecosystemHtml = versionAssets(readFileSync(join(TEMPLATES, 'ecosystem.html'), 'utf-8'));
+  const ecosystemHtml = renderTemplate('ecosystem.html');
   writeFileSync(join(DIST, 'ecosystem.html'), ecosystemHtml);
   console.log('  Built ecosystem.html');
 
   // Copy runtime.html
-  const runtimeHtml = versionAssets(readFileSync(join(TEMPLATES, 'runtime.html'), 'utf-8'));
+  const runtimeHtml = renderTemplate('runtime.html');
   writeFileSync(join(DIST, 'runtime.html'), runtimeHtml);
   console.log('  Built runtime.html');
 
@@ -214,7 +233,7 @@ function build() {
 }
 
 function buildLegalPage(page) {
-  const template = versionAssets(readFileSync(join(TEMPLATES, 'legal.html'), 'utf-8'));
+  const template = renderTemplate('legal.html');
   const markdown = readFileSync(join(CONTENT, page.source), 'utf-8');
   const content = marked.parse(markdown);
   const rendered = template
@@ -233,7 +252,7 @@ function buildLegalPage(page) {
 }
 
 function buildSpec({ entries, output: outputFile, title, version, switchLink }) {
-  const specTemplate = versionAssets(readFileSync(join(TEMPLATES, 'spec.html'), 'utf-8'));
+  const specTemplate = renderTemplate('spec.html');
 
   // Build sidebar links
   let sidebarHtml = '';

--- a/site/static/mdbase-favicon.svg
+++ b/site/static/mdbase-favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="18 18 84 84">
+  <g fill="#131921">
+    <rect x="22" y="22" width="20" height="10" rx="2"/>
+    <rect x="50" y="22" width="20" height="10" rx="2"/>
+    <rect x="78" y="22" width="20" height="10" rx="2"/>
+    <rect x="22" y="44" width="12" height="10" rx="2"/>
+    <rect x="22" y="66" width="28" height="10" rx="2"/>
+    <rect x="58" y="66" width="40" height="10" rx="2"/>
+    <rect x="22" y="88" width="20" height="10" rx="2"/>
+    <rect x="50" y="88" width="20" height="10" rx="2"/>
+    <rect x="78" y="88" width="20" height="10" rx="2"/>
+  </g>
+  <rect x="42" y="44" width="56" height="10" rx="2" fill="#005c88"/>
+</svg>

--- a/site/static/style.css
+++ b/site/static/style.css
@@ -342,7 +342,7 @@ td {
 .landing-logo {
   display: inline-flex;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.5rem;
   color: var(--ink);
   font-family: var(--mono);
   font-size: 0.88rem;
@@ -354,11 +354,19 @@ td {
   color: var(--ink);
 }
 
-.landing-logo .dot {
-  width: 0.42rem;
-  height: 0.42rem;
-  border-radius: 50%;
-  background: var(--accent);
+.mdbase-mark {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex: 0 0 auto;
+  overflow: visible;
+}
+
+.mdbase-mark-ink {
+  fill: currentColor;
+}
+
+.mdbase-mark-accent {
+  fill: var(--accent);
 }
 
 .landing-nav {

--- a/site/templates/ecosystem.html
+++ b/site/templates/ecosystem.html
@@ -10,7 +10,7 @@
   <meta property="og:url" content="https://mdbase.dev/ecosystem">
   <meta property="og:type" content="website">
   <meta name="theme-color" content="#fdfdfd">
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9670;</text></svg>">
+  <link rel="icon" href="mdbase-favicon.svg" type="image/svg+xml">
   <script src="theme.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
@@ -18,7 +18,7 @@
 
   <header class="landing-header">
     <a href="/" class="landing-logo">
-      <span class="dot"></span>
+      {{MDBASE_MARK}}
       mdbase
     </a>
     <nav class="landing-nav" aria-label="Primary">

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -10,13 +10,13 @@
   <meta property="og:url" content="https://mdbase.dev">
   <meta property="og:type" content="website">
   <meta name="theme-color" content="#fdfdfd">
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9670;</text></svg>">
+  <link rel="icon" href="mdbase-favicon.svg" type="image/svg+xml">
   <script src="theme.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="site-page">
   <header class="landing-header">
-    <a href="/" class="landing-logo"><span class="dot"></span>mdbase</a>
+    <a href="/" class="landing-logo">{{MDBASE_MARK}}mdbase</a>
     <nav class="landing-nav" aria-label="Primary">
       <a href="runtime.html">Runtime</a>
       <a href="ecosystem.html">Ecosystem</a>

--- a/site/templates/legal.html
+++ b/site/templates/legal.html
@@ -11,13 +11,13 @@
   <meta property="og:type" content="website">
   <meta name="theme-color" content="#fdfdfd">
   <link rel="canonical" href="{{PAGE_URL}}">
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9670;</text></svg>">
+  <link rel="icon" href="/mdbase-favicon.svg" type="image/svg+xml">
   <script src="/theme.js"></script>
   <link rel="stylesheet" href="/style.css">
 </head>
 <body class="site-page legal-site-page">
   <header class="landing-header">
-    <a href="/" class="landing-logo"><span class="dot"></span>mdbase</a>
+    <a href="/" class="landing-logo">{{MDBASE_MARK}}mdbase</a>
     <nav class="landing-nav" aria-label="Primary">
       <a href="/">Home</a>
       <a href="/runtime.html">Runtime</a>

--- a/site/templates/runtime.html
+++ b/site/templates/runtime.html
@@ -10,13 +10,13 @@
   <meta property="og:url" content="https://mdbase.dev/runtime">
   <meta property="og:type" content="website">
   <meta name="theme-color" content="#fdfdfd">
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9670;</text></svg>">
+  <link rel="icon" href="mdbase-favicon.svg" type="image/svg+xml">
   <script src="theme.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="site-page runtime-page">
   <header class="landing-header">
-    <a href="/" class="landing-logo"><span class="dot"></span>mdbase</a>
+    <a href="/" class="landing-logo">{{MDBASE_MARK}}mdbase</a>
     <nav class="landing-nav" aria-label="Primary">
       <a href="/">Home</a>
       <a href="runtime.html" class="nav-active">Runtime</a>

--- a/site/templates/spec.html
+++ b/site/templates/spec.html
@@ -6,7 +6,7 @@
   <title>{{SPEC_TITLE}} - mdbase</title>
   <meta name="description" content="The full mdbase specification for typed markdown collections.">
   <meta name="theme-color" content="#fdfdfd">
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9670;</text></svg>">
+  <link rel="icon" href="mdbase-favicon.svg" type="image/svg+xml">
   <script src="theme.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
@@ -18,7 +18,7 @@
         Sections
       </button>
       <a href="/" class="landing-logo">
-        <span class="dot"></span>
+        {{MDBASE_MARK}}
         mdbase
       </a>
       <span class="spec-version">{{SPEC_VERSION}}</span>


### PR DESCRIPTION
Replaces the temporary diamond/dot identity across the generated specification site, adds the shared favicon, and documents its use. Validated with the site build, conformance guard, rendered light/dark review, SVG validation, and diff checks.