### PR TITLE
Define the canonical record document contract

### DIFF
--- a/03-records-and-frontmatter.md
+++ b/03-records-and-frontmatter.md
@@ -25,7 +25,7 @@ frontmatter.
 
 Frontmatter MUST parse to a YAML mapping. Empty frontmatter is an empty mapping.
 
-If frontmatter is absent, the raw frontmatter object is `{}`.
+If frontmatter is absent, the persisted frontmatter object is `{}`.
 
 If frontmatter parses to a scalar, sequence, or other non-mapping value, the
 record is invalid at validation level `error`. At validation level `warn`, tools
@@ -45,14 +45,44 @@ These states are not interchangeable.
 `collection.read_defaults` applies only to missing keys. It does not replace
 explicit null.
 
-## Raw And Effective Records
+## Persisted And Effective Frontmatter
 
-A raw record is the persisted frontmatter object plus file metadata and body.
+`frontmatter` always means the parsed mapping persisted in the Markdown file.
+It does not contain read defaults, computed values, or other derived data.
 
-An effective record is a read/query view that may apply `collection.read_defaults`
-for matched types.
+`effective_frontmatter` is the derived read/query mapping after applying
+`collection.read_defaults` and any other read-time computation supported by the
+active profile.
 
-Validation of JSON Schema `required` is against the raw or draft persisted
+These names have fixed meanings in every operation and provider. An operation
+MUST NOT place effective values in `frontmatter`, place persisted values in
+`effective_frontmatter`, or change either meaning based on request options.
+
+A complete record document has this shape:
+
+```yaml
+path: tasks/fix-login.md
+revision: sha256:opaque
+types: [task]
+frontmatter:
+  title: Fix login
+effective_frontmatter:
+  title: Fix login
+  status: open
+body: |
+  Reproduce and fix the login failure.
+file:
+  name: fix-login.md
+  folder: tasks
+  size: 142
+  mtime: 2026-07-26T03:00:00Z
+```
+
+`path`, `revision`, `types`, `frontmatter`, `effective_frontmatter`, `body`, and
+`file` are all required on a complete record document. Empty frontmatter is
+represented by `{}`, not by an absent member.
+
+Validation of JSON Schema `required` is against the persisted or draft
 frontmatter object, not against effective read defaults.
 
 ## Body

--- a/11-querying.md
+++ b/11-querying.md
@@ -211,16 +211,18 @@ cannot read bodies on demand.
 
 ## Frontmatter Mode
 
-`frontmatter` controls which record frontmatter appears in each result:
+`frontmatter_mode` controls which fixed-semantics frontmatter members appear in
+each result:
 
-- `effective` (the default) returns effective values in `frontmatter`
-- `raw` returns raw persisted values in `frontmatter`
-- `both` returns effective values in `frontmatter` and raw persisted values in
-  `raw_frontmatter`
+- `effective` (the default) returns `effective_frontmatter`
+- `persisted` returns `frontmatter`
+- `both` returns both `frontmatter` and `effective_frontmatter`
 
 The mode changes result serialization only. Filtering, projections, selection,
 ordering, grouping, and summaries continue to use effective values unless an
-expression explicitly reads the raw namespace.
+expression explicitly reads the persisted namespace. Unlike a complete record
+document returned by Core Read or a mutation, a query result is a summary and
+MAY omit the member excluded by the requested mode.
 
 ## Result Envelope
 
@@ -230,7 +232,7 @@ Query results MUST use this envelope:
 results:
   - file:
       path: tasks/fix-login.md
-    frontmatter:
+    effective_frontmatter:
       title: Fix login
       status: open
     values:
@@ -254,7 +256,7 @@ Each result MUST include `file.path`. `meta.total_count` is the count before
 pagination, and `meta.has_more` is true when additional matching records remain.
 Diagnostics use the canonical diagnostic envelope from the conformance chapter.
 
-Read defaults are included in effective frontmatter. `values` contains
+Read defaults are included in `effective_frontmatter`. `values` contains
 requested selection values and is omitted when `select` is omitted.
 
 `meta.context.path` identifies the bound invocation context and is omitted when

--- a/12-operations.md
+++ b/12-operations.md
@@ -27,14 +27,16 @@ Optional saved-view operations:
 
 Read returns a record by path, including:
 
-- raw frontmatter
-- effective frontmatter when requested
-- body when requested
+- persisted `frontmatter`
+- derived `effective_frontmatter`
+- body
 - file metadata
 - matched type names
 - diagnostics
 
 Read MUST NOT write defaults or lifecycle values to disk.
+Every successful read returns the complete record document defined in Chapter
+03.
 
 ## Create
 
@@ -240,10 +242,19 @@ result: {}
 diagnostics: []
 ```
 
-`valid` is false when any error-severity diagnostic applies. Mutating results
-MUST report the final path, raw persisted frontmatter, matched types, and new
-revision when a record was written. Dry runs use the same envelope and MUST NOT
-change files, indexes, runtime state, or revisions.
+`valid` is false when any error-severity diagnostic applies. Successful
+`create`, `update`, and `rename` operations MUST return the complete,
+authoritative post-write record document defined in Chapter 03. `rename` adds
+its rename-specific metadata to that document.
+
+The document MUST be derived from the bytes actually persisted after lifecycle
+hooks, normalization, validation, and the atomic write complete. Clients and
+transport adapters MUST NOT reconstruct missing document members from the
+request or from another response member.
+
+Dry runs return operation-specific preflight results rather than record
+documents. They use the same envelope and MUST NOT change files, indexes,
+runtime state, or revisions.
 
 ## Events
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this specification and conformance suite are documented here.
 
+## 2026-07-26 (v0.3.0 record contract)
+
+### Changed
+
+- Defined `frontmatter` as persisted record data and
+  `effective_frontmatter` as the derived read/query view across all providers.
+- Required Core Read and successful create, update, and rename operations to
+  return the same complete authoritative record document.
+- Replaced the query `frontmatter` option with `frontmatter_mode` and removed
+  the overloaded `raw_frontmatter` result member.
+
 ## 2026-07-24 (v0.3.0 runtime RC)
 
 ### Added

--- a/packages/runtime-contracts/scripts/generate-schema-module.mjs
+++ b/packages/runtime-contracts/scripts/generate-schema-module.mjs
@@ -10,6 +10,7 @@ const schemaPaths = {
   conformanceClaim: "conformance-claim.schema.json",
   coreDiagnostic: "diagnostic.schema.json",
   operationResult: "operation-result.schema.json",
+  recordDocument: "record-document.schema.json",
   queryResult: "query-result.schema.json",
   typeFile: "type-file.schema.json",
   provider: "runtime/provider.schema.json",

--- a/packages/runtime-contracts/src/canonical-schemas.ts
+++ b/packages/runtime-contracts/src/canonical-schemas.ts
@@ -8,6 +8,7 @@ export interface CanonicalSchemas {
   conformanceClaim: Record<string, unknown>;
   coreDiagnostic: Record<string, unknown>;
   operationResult: Record<string, unknown>;
+  recordDocument: Record<string, unknown>;
   queryResult: Record<string, unknown>;
   typeFile: Record<string, unknown>;
   provider: Record<string, unknown>;

--- a/packages/runtime-contracts/src/generated-schemas.ts
+++ b/packages/runtime-contracts/src/generated-schemas.ts
@@ -634,6 +634,74 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
     },
     "additionalProperties": false
   },
+  "recordDocument": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://mdbase.dev/schemas/v0.3/record-document.schema.json",
+    "title": "mdbase v0.3 record document",
+    "type": "object",
+    "required": [
+      "path",
+      "revision",
+      "types",
+      "frontmatter",
+      "effective_frontmatter",
+      "body",
+      "file"
+    ],
+    "properties": {
+      "path": {
+        "type": "string",
+        "minLength": 1
+      },
+      "revision": {
+        "type": "string",
+        "minLength": 1
+      },
+      "types": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "frontmatter": {
+        "type": "object"
+      },
+      "effective_frontmatter": {
+        "type": "object"
+      },
+      "body": {
+        "type": "string"
+      },
+      "file": {
+        "type": "object",
+        "required": [
+          "name",
+          "folder",
+          "size",
+          "mtime"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "folder": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "mtime": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "additionalProperties": false
+  },
   "queryResult": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://mdbase.dev/schemas/v0.3/query-result.schema.json",
@@ -669,7 +737,7 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
             "frontmatter": {
               "type": "object"
             },
-            "raw_frontmatter": {
+            "effective_frontmatter": {
               "type": "object"
             },
             "values": {

--- a/packages/runtime-contracts/src/schemas.ts
+++ b/packages/runtime-contracts/src/schemas.ts
@@ -31,6 +31,7 @@ export async function loadCanonicalSchemas(schemaRoot?: string): Promise<Canonic
     conformanceClaim: await readJson(join(schemaRoot, "conformance-claim.schema.json")),
     coreDiagnostic: await readJson(join(schemaRoot, "diagnostic.schema.json")),
     operationResult: await readJson(join(schemaRoot, "operation-result.schema.json")),
+    recordDocument: await readJson(join(schemaRoot, "record-document.schema.json")),
     queryResult: await readJson(join(schemaRoot, "query-result.schema.json")),
     typeFile: await readJson(join(schemaRoot, "type-file.schema.json")),
     provider: await readJson(join(schemaRoot, "runtime/provider.schema.json")),

--- a/schemas/v0.3/README.md
+++ b/schemas/v0.3/README.md
@@ -12,6 +12,7 @@ yet published package artifacts.
 | `type-file.schema.json` | frontmatter of `_types/*.md` v0.3 type files |
 | `query.schema.json` | portable query input objects |
 | `query-result.schema.json` | query results plus optional context, view, grouping, and summary metadata |
+| `record-document.schema.json` | complete authoritative record documents returned by read and successful mutations |
 | `view.schema.json` | ordinary `type: view` record frontmatter |
 | `conformance-claim.schema.json` | machine-readable implementation profile claims and evidence |
 | `runtime/provider.schema.json` | provider contract records |

--- a/schemas/v0.3/query-result.schema.json
+++ b/schemas/v0.3/query-result.schema.json
@@ -25,7 +25,7 @@
           "frontmatter": {
             "type": "object"
           },
-          "raw_frontmatter": {
+          "effective_frontmatter": {
             "type": "object"
           },
           "values": {

--- a/schemas/v0.3/query.schema.json
+++ b/schemas/v0.3/query.schema.json
@@ -16,8 +16,8 @@
     "limit": { "type": "integer", "minimum": 0 },
     "offset": { "type": "integer", "minimum": 0 },
     "include_body": { "type": "boolean", "default": false },
-    "frontmatter": {
-      "enum": ["effective", "raw", "both"],
+    "frontmatter_mode": {
+      "enum": ["effective", "persisted", "both"],
       "default": "effective"
     }
   },

--- a/schemas/v0.3/record-document.schema.json
+++ b/schemas/v0.3/record-document.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/v0.3/record-document.schema.json",
+  "title": "mdbase v0.3 record document",
+  "type": "object",
+  "required": [
+    "path",
+    "revision",
+    "types",
+    "frontmatter",
+    "effective_frontmatter",
+    "body",
+    "file"
+  ],
+  "properties": {
+    "path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "revision": {
+      "type": "string",
+      "minLength": 1
+    },
+    "types": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "frontmatter": {
+      "type": "object"
+    },
+    "effective_frontmatter": {
+      "type": "object"
+    },
+    "body": {
+      "type": "string"
+    },
+    "file": {
+      "type": "object",
+      "required": ["name", "folder", "size", "mtime"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "folder": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "mtime": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/v0.3/view.schema.json
+++ b/schemas/v0.3/view.schema.json
@@ -158,8 +158,8 @@
         "limit": { "type": "integer", "minimum": 0 },
         "offset": { "type": "integer", "minimum": 0 },
         "include_body": { "type": "boolean", "default": false },
-        "frontmatter": {
-          "enum": ["effective", "raw", "both"],
+        "frontmatter_mode": {
+          "enum": ["effective", "persisted", "both"],
           "default": "effective"
         },
         "presentation": { "$ref": "#/$defs/presentation" }

--- a/tests/v0.3/core/core-collection.yaml
+++ b/tests/v0.3/core/core-collection.yaml
@@ -528,10 +528,9 @@ groups:
         operation: read
         input:
           path: "tasks/valid.md"
-          effective: true
         expect:
           valid: true
-          frontmatter:
+          effective_frontmatter:
             status: open
 
       - name: "read defaults do not replace explicit null"
@@ -540,19 +539,17 @@ groups:
         operation: read
         input:
           path: "tasks/null-status.md"
-          effective: true
         expect:
           valid: true
-          frontmatter:
+          effective_frontmatter:
             status: null
 
-      - name: "raw read does not materialize read defaults"
-        id: collection.raw_read
+      - name: "persisted frontmatter does not materialize read defaults"
+        id: collection.persisted_read
         covers: [collection_semantics.effective_read_defaults]
         operation: read
         input:
           path: "tasks/valid.md"
-          effective: false
         expect:
           valid: true
           frontmatter_not_contains:

--- a/tests/v0.3/fixtures/valid-record-document.yml
+++ b/tests/v0.3/fixtures/valid-record-document.yml
@@ -1,0 +1,16 @@
+path: tasks/fix-login.md
+revision: "sha256:opaque"
+types:
+  - task
+frontmatter:
+  title: Fix login
+effective_frontmatter:
+  title: Fix login
+  status: open
+body: |
+  Reproduce and fix the login failure.
+file:
+  name: fix-login.md
+  folder: tasks
+  size: 142
+  mtime: "2026-07-26T03:00:00Z"

--- a/tests/v0.3/fixtures/views/valid-query.yml
+++ b/tests/v0.3/fixtures/views/valid-query.yml
@@ -28,4 +28,4 @@ summaries:
 limit: 20
 offset: 0
 include_body: false
-frontmatter: both
+frontmatter_mode: both

--- a/tests/v0.3/lifecycle/lifecycle.yaml
+++ b/tests/v0.3/lifecycle/lifecycle.yaml
@@ -105,10 +105,9 @@ groups:
         operation: read
         input:
           path: "tasks/existing.md"
-          effective: true
         expect:
           valid: true
-          frontmatter:
+          effective_frontmatter:
             status: open
 
   - name: "lifecycle guards and conflicts"

--- a/tests/v0.3/schema/schema-artifacts.yaml
+++ b/tests/v0.3/schema/schema-artifacts.yaml
@@ -105,6 +105,15 @@ groups:
         expect:
           valid: false
 
+      - name: "record document schema validates the complete canonical shape"
+        operation: yaml_document_schema_validate
+        input:
+          schema: "schemas/v0.3/record-document.schema.json"
+          paths:
+            - "tests/v0.3/fixtures/valid-record-document.yml"
+        expect:
+          valid: true
+
       - name: "view schema validates a portable task view record"
         operation: markdown_frontmatter_schema_validate
         input:


### PR DESCRIPTION
## Summary
- give persisted `frontmatter` and derived `effective_frontmatter` fixed meanings
- require read and successful record mutations to return one complete record document
- replace overloaded query and saved-view frontmatter options with `frontmatter_mode`
- publish and embed a canonical record-document schema

## Verification
- `npm test --prefix packages/runtime-contracts`
- `python3 scripts/check_test_levels.py`
- `python3 scripts/check_v03_tests.py`
- `python3 scripts/check_v03_claim.py tests/v0.3/fixtures/conformance/valid-core-read.yml tests/v0.3/fixtures/conformance/valid-all-profile-dependencies.yml`