### PR TITLE
Add portable CEL membership conformance

### DIFF
--- a/tests/v0.3/cel/cel-profile.yaml
+++ b/tests/v0.3/cel/cel-profile.yaml
@@ -213,6 +213,7 @@ groups:
         payload:
           file:
             path: tasks/card-001.md
+          types: [pickle_request]
           zone:
             id: doing
       steps:
@@ -226,6 +227,31 @@ groups:
         input:
           context: workflow
           expression: 'event.payload.file.path == "tasks/card-001.md" && event.payload.zone.id == "doing"'
+        expect:
+          valid: true
+          value: true
+
+      - name: "record event type membership uses the CEL in operator"
+        id: cel.record_type_membership
+        covers:
+          - cel.portable_evaluation
+        operation: evaluate_cel
+        input:
+          context: workflow
+          expression: '"pickle_request" in event.payload.types'
+        expect:
+          valid: true
+          value: true
+
+      - name: "workflow CEL supports presence and comprehension macros"
+        id: cel.workflow_macros
+        covers:
+          - cel.portable_evaluation
+          - cel.context_bindings
+        operation: evaluate_cel
+        input:
+          context: workflow
+          expression: 'has(event.payload.file) && !has(event.payload.missing) && event.payload.types.exists(t, t == "pickle_request")'
         expect:
           valid: true
           value: true


### PR DESCRIPTION
## Summary
- add the exact Pickle event criterion, `"pickle_request" in event.payload.types`, to the shared CEL conformance profile
- cover CEL `has` and collection macros used by portable workflow expressions
- keep the fixtures consumable by runtime implementations as cross-language behavior checks

## Verification
- consumed by the mdbase-rs conformance suite (15 cases)
- `cargo test --workspace --all-targets` in mdbase-rs
- `git diff --check`