### PR TITLE
Define exact record documents

### DIFF
--- a/03-records-and-frontmatter.md
+++ b/03-records-and-frontmatter.md
@@ -71,6 +71,11 @@ effective_frontmatter:
   status: open
 body: |
   Reproduce and fix the login failure.
+document: |
+  ---
+  title: Fix login
+  ---
+  Reproduce and fix the login failure.
 file:
   name: fix-login.md
   folder: tasks
@@ -81,6 +86,14 @@ file:
 `path`, `revision`, `types`, `frontmatter`, `effective_frontmatter`, `body`, and
 `file` are all required on a complete record document. Empty frontmatter is
 represented by `{}`, not by an absent member.
+
+`document` is an optional complete UTF-8 source representation. It is returned
+when an operation explicitly requests source and MUST contain the exact record
+text whose bytes produced `revision`, including any byte-order mark, YAML
+delimiters, comments, quoting, whitespace, line endings, and trailing newline.
+`frontmatter` and `body` MUST be parsed from that same text. Providers MUST NOT
+reconstruct `document` from parsed frontmatter and body when exact source is
+unavailable.
 
 Validation of JSON Schema `required` is against the persisted or draft
 frontmatter object, not against effective read defaults.

--- a/12-operations.md
+++ b/12-operations.md
@@ -38,6 +38,11 @@ Read MUST NOT write defaults or lifecycle values to disk.
 Every successful read returns the complete record document defined in Chapter
 03.
 
+Read accepts optional `include_document`. When true, the returned record MUST
+include the exact `document` source defined in Chapter 03. Providers that
+cannot supply exact source MUST reject the request rather than silently return
+a reconstructed serialization.
+
 ## Create
 
 Create builds a new record.
@@ -80,6 +85,19 @@ Pipeline:
 If a patch sets a field to missing, the key is removed. If a patch sets a field
 to null, the key is persisted as null unless the operation policy says null
 means remove.
+
+As an alternative to a frontmatter patch and body replacement, Update accepts
+`document` containing the complete candidate Markdown source. A document
+replacement MUST NOT be combined with `patch`, `fields`, `frontmatter`, or
+`body`. The candidate is parsed and passes through the same type matching,
+lifecycle, validation, concurrency, and atomic-write pipeline as a structured
+update. When lifecycle policy does not alter the candidate, the exact supplied
+source MUST be preserved. If policy changes persisted values, the authoritative
+post-policy source MAY be reserialized and is returned when source was
+requested.
+
+Update accepts optional `include_document`. A document replacement implies
+`include_document: true` for its successful result.
 
 ## Delete
 
@@ -251,6 +269,10 @@ The document MUST be derived from the bytes actually persisted after lifecycle
 hooks, normalization, validation, and the atomic write complete. Clients and
 transport adapters MUST NOT reconstruct missing document members from the
 request or from another response member.
+
+Create and rename accept optional `include_document`; when true, their
+successful record document includes the exact post-write source. Update follows
+the source rules above.
 
 Dry runs return operation-specific preflight results rather than record
 documents. They use the same envelope and MUST NOT change files, indexes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this specification and conformance suite are documented here.
 
+## 2026-07-26 (exact record source)
+
+### Added
+
+- Added opt-in exact `document` source to complete record results.
+- Added whole-document record updates with the same validation, lifecycle, and
+  revision guarantees as structured updates.
+
 ## 2026-07-26 (v0.3.0 record contract)
 
 ### Changed

--- a/schemas/v0.3/record-document.schema.json
+++ b/schemas/v0.3/record-document.schema.json
@@ -37,6 +37,9 @@
     "body": {
       "type": "string"
     },
+    "document": {
+      "type": "string"
+    },
     "file": {
       "type": "object",
       "required": ["name", "folder", "size", "mtime"],

--- a/tests/v0.3/fixtures/valid-record-document.yml
+++ b/tests/v0.3/fixtures/valid-record-document.yml
@@ -9,6 +9,11 @@ effective_frontmatter:
   status: open
 body: |
   Reproduce and fix the login failure.
+document: |
+  ---
+  title: Fix login
+  ---
+  Reproduce and fix the login failure.
 file:
   name: fix-login.md
   folder: tasks


### PR DESCRIPTION
Adds the optional exact `document` field and `include_document` request control, defines whole-document replacement semantics and mutual exclusivity, and adds conformance coverage for byte-preserving record source.\n\nValidation: `python3 scripts/check_v03_tests.py` (37 executable tests, 91 adapter targets).