### PR TITLE
Define first-class data contracts and type packs

### DIFF
--- a/00-overview.md
+++ b/00-overview.md
@@ -170,6 +170,18 @@ JSON Schema validates the persisted frontmatter object. The `collection`
 section supplies rules that require collection context, including effective
 read defaults, links, uniqueness, and path policy.
 
+### Data contracts make type meaning portable
+
+Types can implement exact, versioned data contracts stored under
+`_contracts/`. A contract uses JSON Schema for its normalized record interface
+and optional binding. The type's `implements` entry maps contract fields to
+record fields.
+
+Several types can implement one contract, and several applications can consume
+the same type. Discovery returns the complete implementation set; it never
+silently picks a provider. Data contracts are passive interoperability and do
+not grant access.
+
 ### Records are Markdown files with typed frontmatter
 
 A record provides field values in frontmatter and free-form Markdown in its
@@ -264,6 +276,7 @@ testable.
 | [03-records-and-frontmatter.md](./03-records-and-frontmatter.md) | Markdown parsing and YAML value semantics |
 | [04-configuration.md](./04-configuration.md) | The `mdbase.yaml` configuration file |
 | [05-type-files.md](./05-type-files.md) | JSON Schema type wrappers and metadata |
+| [05-data-contracts.md](./05-data-contracts.md) | versioned data contracts, type implementations, and transactional type packs |
 | [06-json-schema-profile.md](./06-json-schema-profile.md) | Supported JSON Schema vocabulary and reference rules |
 | [07-collection-semantics.md](./07-collection-semantics.md) | Matching, defaults, uniqueness, links, and paths |
 | [08-links.md](./08-links.md) | Link syntax, resolution, traversal, and backlinks |

--- a/01-concepts.md
+++ b/01-concepts.md
@@ -3,15 +3,15 @@
 ## Collection
 
 A collection is a directory tree identified by an `mdbase.yaml` file. It
-contains Markdown records, type files, optional runtime records, and optional
-derived state.
+contains Markdown records, type files, optional data contract files, optional
+runtime records, and optional derived state.
 
 A collection root is the directory containing the active `mdbase.yaml`.
 
 ## Record
 
 A record is a Markdown file in the collection that is not excluded, not a type
-file, and not another reserved collection file. A record has:
+or data contract file, and not another reserved collection file. A record has:
 
 - a collection-relative path
 - optional YAML frontmatter
@@ -30,6 +30,17 @@ mdbase sections.
 
 Types define shape and collection semantics for matching records. Runtime
 providers and workflows supply executable behavior.
+
+## Data Contract
+
+A data contract is a versioned `mdbase.contract` control file that defines a
+portable record interface and optional implementation binding using JSON Schema
+2020-12.
+
+A type implements a data contract through its top-level `implements` section.
+The contract does not replace the type, select a provider, assign ownership, or
+grant access. Several types can implement one contract, and several
+applications can consume the same implementing type.
 
 ## Schema
 
@@ -114,16 +125,16 @@ runtime-profile behavior for a collection.
 The core collection model is runtime-neutral. Runtime records make active
 behavior portable and inspectable without making every implementation a runtime.
 
-## Contract
+## Runtime Contract
 
-A contract is a typed record or virtual registry entry describing the interface
-of a provider, event, action, capability, policy, run, checkpoint, diagnostic,
-or workflow.
+A runtime contract is a typed record or virtual registry entry describing the
+interface of a provider, event, action, capability, policy, run, checkpoint,
+diagnostic, or workflow.
 
-Contracts describe the interfaces used by action handlers, event sources,
-watchers, schedulers, agents, and provider APIs supplied by a runtime.
+Runtime contracts describe the interfaces used by action handlers, event
+sources, watchers, schedulers, agents, and provider APIs supplied by a runtime.
 
-## Explicit And Implicit Contracts
+## Explicit And Implicit Runtime Contracts
 
 Explicit contracts are ordinary Markdown records in a collection or installed
 pack.

--- a/02-collection-layout.md
+++ b/02-collection-layout.md
@@ -23,6 +23,8 @@ collection/
     workflow.md
     action.md
     event.md
+  _contracts/
+    example.task.md
   actions/
     mdbase.record.patch.md
   events/
@@ -48,6 +50,7 @@ The following paths are reserved by default:
 
 - `mdbase.yaml`
 - the configured types folder, default `_types/`
+- the configured contracts folder, default `_contracts/`
 - `.mdbase/` for derived implementation state
 - nested collection roots
 
@@ -70,6 +73,7 @@ Tools MUST:
 - use forward slash paths in collection APIs
 - skip excluded paths
 - skip the configured types folder
+- skip the configured contracts folder
 - skip `.mdbase/`
 - stop scanning at nested collection roots
 - ignore non-record extensions unless configured otherwise
@@ -86,6 +90,18 @@ frontmatter declares `kind: mdbase.type` is a candidate type definition.
 
 Tools MAY warn for files under the types folder that are not valid type files.
 They MUST NOT treat type files as data records.
+
+## Data Contract Discovery
+
+The configured `contracts_folder` defaults to `_contracts`.
+
+Every Markdown file directly or recursively under the contracts folder whose
+frontmatter declares `kind: mdbase.contract` is a candidate data contract.
+Contract loading, exact-version identity, and implementation validation are
+defined in Chapter 05A.
+
+Tools MAY warn for files under the contracts folder that are not valid contract
+files. They MUST NOT treat data contract files as records.
 
 ## Runtime Record Discovery
 

--- a/04-configuration.md
+++ b/04-configuration.md
@@ -18,6 +18,7 @@ spec_version: "0.3.0"
 
 settings:
   types_folder: _types
+  contracts_folder: _contracts
   record_extensions: [md]
   validation: error
   explicit_type_keys: [type, types]
@@ -43,6 +44,7 @@ Pre-1.0 draft versions MAY be accepted by explicit compatibility setting.
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `settings.types_folder` | string | `_types` | folder containing type files |
+| `settings.contracts_folder` | string | `_contracts` | folder containing data contract files |
 | `settings.record_extensions` | list of strings | `[md]` | record file extensions without dot |
 | `settings.validation` | string | `error` | default validation level: `off`, `warn`, or `error` |
 | `settings.explicit_type_keys` | list of strings | `[type, types]` | frontmatter keys used for explicit type declarations |
@@ -52,6 +54,9 @@ Pre-1.0 draft versions MAY be accepted by explicit compatibility setting.
 
 `settings.explicit_type_keys` replaces the default key list. An empty list makes
 all type membership inferred.
+
+The types and contracts folders MUST be different normalized paths. Both are
+reserved control-file folders and are excluded from ordinary record discovery.
 
 Unknown config keys MUST produce a warning while normal config loading
 continues. An explicit strict-config mode MAY reject them.

--- a/05-data-contracts.md
+++ b/05-data-contracts.md
@@ -180,7 +180,8 @@ Digests let a consumer distinguish an approved implementation from a later
 change that happens to retain the same name.
 
 The contract digest is SHA-256 over RFC 8785 JSON Canonicalization Scheme bytes
-for this object:
+for this object, using the fully resolved JSON Schema values rather than their
+storage wrappers or reference paths:
 
 ```json
 {
@@ -193,7 +194,11 @@ for this object:
 ```
 
 `binding_schema` is omitted when absent. Human-facing `name`, `description`,
-Markdown body, and `x-*` metadata do not affect portable identity.
+Markdown body, `x-*` metadata, schema wrapper dialects, and local `ref` paths
+do not affect portable identity. Consequently, an inline schema and a local
+referenced schema with identical resolved JSON values have the same contract
+digest, while changing the bytes at a stable reference path changes the
+digest.
 
 The implementation digest is SHA-256 over RFC 8785 bytes for:
 
@@ -246,8 +251,11 @@ read or mutate it.
 ## Contract Access And Whole Records
 
 The portable contract view contains only mapped contract fields. A gateway that
-grants access "through a contract" SHOULD expose that view plus the minimum
-record identity needed by its protocol.
+grants access "through a contract" MUST expose only that view plus the minimum
+record identity needed by its protocol. If a record has several approved views
+and the operation does not identify one unambiguously, the gateway MUST require
+an explicit contract ID, exact version, and implementing type rather than merge
+or guess.
 
 Access to unmapped frontmatter, the Markdown body, or arbitrary records is
 whole-record or whole-collection access and MUST be requested and presented
@@ -308,6 +316,13 @@ complete committed state before normal collection operations resume.
 Revoking an application's access does not uninstall its type pack. Uninstall is
 a separate, explicitly requested operation because records may still depend on
 the installed types.
+
+A pack install or dry-run result reports the pack `id`, exact `version`, and
+every resource in manifest order as `{ target, action, digest }`, where
+`action` is `create`, `replace`, or `unchanged`. It also reports
+`cleanup_deferred` when committed state is valid but transaction-journal cleanup
+must be retried. Reinstalling identical bytes is valid and reports every
+resource as `unchanged`; it MUST NOT create a new logical collection revision.
 
 ## Diagnostics
 

--- a/05-data-contracts.md
+++ b/05-data-contracts.md
@@ -1,0 +1,330 @@
+# 05A. Data Contracts
+
+## Why Data Contracts Exist
+
+A type describes one collection's records. A data contract describes the
+portable meaning that one or more independently designed types agree to expose.
+
+For example, `personal_task`, `work_task`, and `task` can all implement
+`tasknotes.task`. Their filenames, additional fields, matching rules, and local
+presentation can differ. An application can discover the shared contract,
+understand each type's field mapping, and operate without requiring every
+collection to use one canonical type name.
+
+Data contracts are passive data interoperability. They do not describe
+executable actions, events, providers, permissions, or workflows. Those are
+runtime contracts and are defined in Chapter 13.
+
+## Three Portable Artifacts
+
+The complete data-contract model has three intentionally small parts:
+
+1. An `mdbase.contract` artifact defines a versioned interface and optional
+   binding schema using JSON Schema 2020-12.
+2. A type's `implements` entry maps that interface to the type and supplies
+   contract-specific binding data.
+3. An optional `mdbase.type-pack` manifest groups contracts, types, and their
+   referenced schemas for transactional installation.
+
+An application requirement, authorization grant, or network protocol is not a
+fourth collection artifact. Such systems consume the verified facts exposed by
+the collection.
+
+## Contract Files
+
+Contract files are Markdown files under the configured contracts folder,
+default `_contracts/`. Their frontmatter has `kind: mdbase.contract` and
+validates against `schemas/v0.3/data-contract.schema.json`.
+
+```markdown
+---
+kind: mdbase.contract
+id: example.task
+version: 1.0.0
+name: Example task
+description: A small portable task interface.
+
+schema:
+  dialect: json-schema-2020-12
+  value:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    type: object
+    required: [title, status]
+    additionalProperties: false
+    properties:
+      title: { type: string, minLength: 1 }
+      status: { type: string, minLength: 1 }
+      due: { type: string, format: date }
+
+binding_schema:
+  dialect: json-schema-2020-12
+  value:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    type: object
+    required: [completed_values]
+    additionalProperties: false
+    properties:
+      completed_values:
+        type: array
+        minItems: 1
+        uniqueItems: true
+        items: { type: string }
+---
+
+# Example task
+
+The body explains the interface to people. Portable behavior is defined by the
+frontmatter schemas.
+```
+
+`id` is a lower-case namespaced identifier. `version` is an exact semantic
+version. A type implementation never names a version range.
+
+`schema` validates the normalized contract view produced from a record.
+`binding_schema`, when present, validates implementation-specific semantic
+configuration. Both use the same JSON Schema profile and reference rules as
+type schemas.
+
+Contract files are control files, not records. They do not participate in
+ordinary record scans, queries, links, or runtime workflow discovery.
+
+## Contract Registry
+
+During collection load, a data-contract-aware implementation:
+
+1. scans the configured contracts folder recursively
+2. validates every candidate against the built-in data-contract schema
+3. resolves and compiles `schema` and `binding_schema`
+4. registers each contract by the exact pair `(id, version)`
+5. computes its contract digest
+6. validates every type `implements` entry against the resulting registry
+
+Several versions of one contract ID may coexist. Two artifacts with the same
+ID and version are valid only when their contract digests are identical.
+Different content for the same ID and version is
+`data_contract_conflict`.
+
+Resolution is collection-local and offline. Core implementations MUST NOT fetch
+a missing contract from the network. Applications and installers carry the
+contract files they require, usually in a type pack.
+
+## Type Implementations
+
+`implements` belongs in the type file because an implementation is a claim
+about each record that matches that one type.
+
+```yaml
+implements:
+  - contract: example.task
+    version: 1.0.0
+    fields:
+      title: title
+      status: workflow_state
+      due: due_date
+    binding:
+      completed_values: [done, cancelled]
+```
+
+Each implementation contains:
+
+| Key | Meaning |
+| --- | --- |
+| `contract` | exact contract ID |
+| `version` | exact contract semantic version |
+| `fields` | contract field path to record field path mapping |
+| `binding` | optional configuration validated by the contract's `binding_schema` |
+
+Both sides of `fields` use the field-path syntax from Chapter 07. The left side
+addresses the normalized contract view. The right side addresses effective
+record frontmatter. Mapping is direct: core does not rename values, coerce
+values, run expressions, or apply hidden transforms.
+
+A type MUST NOT contain two implementations of the same contract ID and
+version. Field mappings MUST address fields declared by the resolved contract
+schema and the resolved type schema. Every unconditional top-level field named
+by the contract schema's `required` array MUST be mapped.
+
+When a contract has a `binding_schema`, the implementation's `binding` value, or
+an empty object when omitted, MUST validate against it. When a contract has no
+`binding_schema`, `binding` MUST be absent or empty.
+
+Private application metadata may remain under `x-*`, but an `x-*` object has no
+contract-discovery, conformance, or authorization meaning.
+
+## Contract Views And Record Validation
+
+To construct a contract view, a tool starts with a record's effective
+frontmatter and copies every mapped value to its contract field path. Missing
+optional values remain missing. The resulting object is validated against the
+contract's `schema`.
+
+Contract validation complements rather than replaces type validation:
+
+- the type schema validates raw persisted frontmatter
+- collection semantics construct the effective record
+- the field map constructs a normalized contract view
+- the contract schema validates that view
+
+A record can therefore satisfy its type schema and still produce
+`data_contract_record_invalid` for one declared implementation. Implementations
+MUST surface that diagnostic whenever they expose the record through that
+contract.
+
+Static checks at collection load SHOULD diagnose obviously incompatible mapped
+schema types early. Runtime contract-view validation remains authoritative when
+JSON Schema composition makes static implication impractical.
+
+## Stable Digests
+
+Digests let a consumer distinguish an approved implementation from a later
+change that happens to retain the same name.
+
+The contract digest is SHA-256 over RFC 8785 JSON Canonicalization Scheme bytes
+for this object:
+
+```json
+{
+  "kind": "mdbase.contract",
+  "id": "...",
+  "version": "...",
+  "schema": {},
+  "binding_schema": {}
+}
+```
+
+`binding_schema` is omitted when absent. Human-facing `name`, `description`,
+Markdown body, and `x-*` metadata do not affect portable identity.
+
+The implementation digest is SHA-256 over RFC 8785 bytes for:
+
+```json
+{
+  "contract_digest": "sha256:...",
+  "type": {
+    "name": "...",
+    "version": 1,
+    "match": {},
+    "schema": {},
+    "collection": {},
+    "lifecycle": {}
+  },
+  "implementation": {}
+}
+```
+
+Absent optional members are omitted. This deliberately includes membership,
+shape, defaults, links, paths, and lifecycle behavior. A consumer that pinned
+an implementation can detect any portable change that may alter the records or
+values it observes.
+
+Digest strings use `sha256:` followed by 64 lower-case hexadecimal characters.
+
+## Multiple Implementations
+
+A contract lookup returns a set of conforming type implementations, never an
+arbitrarily selected provider.
+
+Multiple applications may consume the same type implementation. Implementing a
+contract does not create an owner, lease, or exclusive provider relationship.
+
+When several types implement one compatible contract requirement:
+
+- read and list experiences SHOULD initially offer their explicit union
+- user-facing approval MUST show every included type
+- an existing approval MUST pin the exact type names, contract digest, and
+  implementation digests
+- a later implementation MUST NOT silently join that approval
+- creation MUST use one explicitly selected implementing type
+
+A product may let a user select a subset instead of the union. It MUST NOT hide
+the selection or silently choose the first filesystem entry.
+
+These rules separate interoperability from authorization. A type's
+`implements` claim says what it can mean; it does not say which application may
+read or mutate it.
+
+## Contract Access And Whole Records
+
+The portable contract view contains only mapped contract fields. A gateway that
+grants access "through a contract" SHOULD expose that view plus the minimum
+record identity needed by its protocol.
+
+Access to unmapped frontmatter, the Markdown body, or arbitrary records is
+whole-record or whole-collection access and MUST be requested and presented
+explicitly. Merely implementing a contract never grants either form of access.
+
+Core collection APIs remain authorization-neutral. This distinction is
+normative for gateways and application protocols that use data contracts as an
+authorization boundary.
+
+## Type Packs
+
+A type pack is a directory or archive with an `mdbase-pack.yaml` manifest that
+validates against `schemas/v0.3/type-pack.schema.json`.
+
+```yaml
+kind: mdbase.type-pack
+id: example.tasks
+version: 1.0.0
+name: Example task types
+resources:
+  - kind: contract
+    source: contracts/example.task.md
+    target: _contracts/example.task.md
+    digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  - kind: type
+    source: types/task.md
+    target: _types/task.md
+    digest: sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
+```
+
+Resource digests are SHA-256 over the exact resource bytes. Source and target
+paths are relative, forward-slash paths without traversal.
+
+Type packs are installation units, not record types and not permission grants.
+A pack may include several contracts, several implementing or auxiliary types,
+and local JSON Schemas referenced by those artifacts.
+
+## Transactional Pack Installation
+
+A pack-aware installer MUST:
+
+1. validate the manifest, safe paths, source bytes, and resource digests
+2. stage every resource without changing the live collection
+3. resolve the complete staged contract and type registries
+4. validate every contract, implementation, type, reference, and affected
+   existing record
+5. compute and present the exact create, replace, and unchanged diff
+6. acquire its collection mutation boundary and recheck overwritten hashes
+7. commit all resources as one recoverable transaction
+8. reopen the collection and verify the committed registry
+
+An invalid resource aborts before any live write. A conflict or concurrent
+change aborts with the live collection unchanged. Implementations may use an
+atomic directory exchange or a durable backup journal with rollback. After a
+crash, recovery MUST restore either the complete pre-install state or the
+complete committed state before normal collection operations resume.
+
+Revoking an application's access does not uninstall its type pack. Uninstall is
+a separate, explicitly requested operation because records may still depend on
+the installed types.
+
+## Diagnostics
+
+Data-contract-aware tools use these codes:
+
+| Code | Meaning |
+| --- | --- |
+| `invalid_data_contract` | contract frontmatter or schema is invalid |
+| `data_contract_not_found` | an implementation references no local exact contract |
+| `data_contract_conflict` | one ID and version resolve to different contract digests |
+| `data_contract_version_mismatch` | a consumer requirement has no compatible exact version |
+| `data_contract_binding_invalid` | implementation binding fails its binding schema |
+| `data_contract_field_invalid` | a mapped contract or record field is missing or incompatible |
+| `data_contract_record_invalid` | a projected contract view fails the contract schema |
+| `invalid_type_pack` | a pack manifest, resource, path, or digest is invalid |
+| `type_pack_conflict` | a target differs from live state and replacement was not approved |
+| `type_pack_apply_failed` | transactional commit or recovery did not complete normally |
+
+Diagnostics use the canonical shape from Chapter 16 and identify the contract
+ID, exact version, type name, and relevant field mapping in `details`.

--- a/05-type-files.md
+++ b/05-type-files.md
@@ -8,6 +8,7 @@ A type file connects three parts of the mdbase model:
 - a JSON Schema for validating their persisted frontmatter
 - collection behavior such as defaults, links, lifecycle assignments, and path
   policy
+- portable data-contract implementations
 
 The YAML frontmatter is the machine-readable definition. The Markdown body can
 document the type for people and tools.
@@ -54,6 +55,8 @@ During collection load, an implementation:
 3. canonicalizes type names for lookup and detects name conflicts
 4. resolves the embedded or referenced JSON Schema
 5. validates and compiles that schema against the v0.3 JSON Schema profile
+6. resolves and validates every `implements` entry against the local data
+   contract registry
 
 Each valid definition then enters the collection's type registry. Diagnostics
 for an invalid definition identify the type-file path and the failing section.
@@ -144,6 +147,7 @@ The following top-level sections are defined by v0.3:
 | `lifecycle` | assign managed values during mutations |
 | `runtime` | attach runtime annotations to the type |
 | `migrations` | declare explicit type-version migration steps |
+| `implements` | declare exact, schema-validated data contract implementations |
 
 Portable type-file validation accepts the core sections and `x-*` extension
 sections. Domain and provider metadata belongs under an extension name:
@@ -151,13 +155,22 @@ sections. Domain and provider metadata belongs under an extension name:
 ```yaml
 x-local:
   owner: research-team
-
-x-example-app:
-  contract: example.task
 ```
 
 This naming rule lets the type-file schema diagnose misspelled core keys such as
 `collecton`.
+
+Portable interoperability metadata does not belong under `x-*`. It uses the
+first-class `implements` section defined in Chapter 05A:
+
+```yaml
+implements:
+  - contract: example.task
+    version: 1.0.0
+    fields:
+      title: title
+      status: status
+```
 
 ## Meta Type
 

--- a/07-collection-semantics.md
+++ b/07-collection-semantics.md
@@ -241,9 +241,10 @@ their declared field names. Query- and view-local named projections are
 separate, live under the `projection` CEL namespace, and never replace a
 collection projection or persisted field with the same name.
 
-## Domain Namespaces
+## Private Domain Namespaces
 
-Domain annotations use namespaced extension sections:
+Private annotations with no portable interoperability meaning use namespaced
+extension sections:
 
 ```yaml
 x-example-app:
@@ -253,5 +254,6 @@ x-example-app:
       completed_values: [done, cancelled]
 ```
 
-This keeps the JSON Schema reusable and gives each domain extension an explicit
-owner.
+This keeps the JSON Schema reusable and gives each private extension an
+explicit owner. Portable domain interfaces use the first-class data contracts
+and type-local `implements` entries from Chapter 05A.

--- a/13-runtime-contracts.md
+++ b/13-runtime-contracts.md
@@ -6,6 +6,11 @@ Runtime contracts let a collection describe event-driven behavior through
 portable records. They give providers, events, actions, capabilities, policies,
 and workflows stable identities and data shapes.
 
+These are runtime contracts, not the passive record-interface data contracts
+defined in Chapter 05A. Runtime contract records participate in the normal
+record model and become active only through a selected runtime host. Data
+contract files are reserved control files implemented by record types.
+
 Contract records describe the interfaces and policy that a runtime uses. The
 runtime supplies event delivery, action handlers, authorization, scheduling,
 and execution.
@@ -120,7 +125,7 @@ Resolution MUST NOT depend on filesystem enumeration order.
 Duplicate contracts with the same ID, version, and canonically identical
 content coalesce. The registry preserves every origin for diagnostics.
 Duplicate IDs with different versions or content MUST produce a
-`contract_conflict` error.
+`runtime_contract_conflict` error.
 
 Runtime profile 0.1 treats non-identical duplicate definitions as conflicts. A
 runtime-specific override uses an `x-*` extension and MUST make the effective

--- a/14-workflows.md
+++ b/14-workflows.md
@@ -381,4 +381,4 @@ explicitly allows it to proceed.
 Built-in, provider, pack, and collection workflows enter the effective registry
 through the composition rules in Chapter 13. Built-in workflows SHOULD be
 inspectable and MAY be materialized. Identical definitions coalesce; conflicting
-definitions produce `contract_conflict` with their origins.
+definitions produce `runtime_contract_conflict` with their origins.

--- a/15-migrations-and-compatibility.md
+++ b/15-migrations-and-compatibility.md
@@ -168,21 +168,29 @@ Generated IDs and timestamps usually become lifecycle.
 Cross-record behavior, agent work, approval flows, external APIs, and scheduled
 checks become workflows and action/event contracts.
 
-## Domain Annotations
+## Data Contract Implementations
 
-Application-specific field annotations migrate to namespaced sections.
+Portable application interfaces migrate to a local data contract plus a
+type-local `implements` entry.
 
 Example:
 
 ```yaml
-x-example-app:
-  fields:
-    status:
-      role: status
+implements:
+  - contract: example.task
+    version: 1.0.0
+    fields:
+      status: status
+    binding:
       completed_values: [done, cancelled]
 ```
 
-They SHOULD NOT become JSON Schema custom keywords in portable v0.3 files.
+The migration bundle MUST include the exact `mdbase.contract` artifact required
+by the implementation. Existing convention-based `x-*` objects do not become
+contracts merely because they contain keys named `contract` or `version`.
+
+Private annotations with no portable contract meaning remain under a
+namespaced `x-*` section. They SHOULD NOT become JSON Schema custom keywords.
 
 ## Version Detection
 

--- a/16-conformance.md
+++ b/16-conformance.md
@@ -8,7 +8,7 @@ queries, writes, runtime preflight, workflow execution, and watching.
 
 | Profile | Purpose |
 | --- | --- |
-| Core Read | discover collections, parse records, load type files, and validate JSON Schema |
+| Core Read | discover collections, parse records, load types and data contracts, and validate JSON Schema |
 | Collection Semantics | apply defaults, uniqueness, path policy, multi-type composition, and collection diagnostics |
 | CEL | compile and evaluate the shared mdbase CEL language and host contract |
 | CEL Match | evaluate `match.expr` against raw candidate records |
@@ -88,8 +88,12 @@ The v0.3 core codes include `unsupported_profile`, `type_conflict`,
 `schema_ref_unresolved`, `schema_ref_cycle`, `format_invalid`,
 `lifecycle_expression_error`, `concurrent_modification`, `invalid_query`,
 `context_not_found`, `context_required`, `context_type_mismatch`,
-`view_not_found`, `invalid_view`, and `unsupported_presentation`. Runtime profile
-0.1 additionally defines `contract_conflict`, `contract_version_mismatch`,
+`view_not_found`, `invalid_view`, `unsupported_presentation`,
+`invalid_data_contract`, `data_contract_not_found`,
+`data_contract_conflict`, `data_contract_version_mismatch`,
+`data_contract_binding_invalid`, `data_contract_field_invalid`, and
+`data_contract_record_invalid`. Runtime profile 0.1 additionally defines
+`runtime_contract_conflict`, `runtime_contract_version_mismatch`,
 `event_provider_mismatch`, `provider_version_mismatch`, `capability_denied`,
 `policy_not_selected`, `executor_not_selected`, and
 `idempotency_unavailable`, `event_cursor_expired`, `stale_lease`,
@@ -103,6 +107,10 @@ Core Read implementations MUST:
 - identify a collection by `mdbase.yaml`
 - scan records using collection-relative forward-slash paths
 - load and validate v0.3 type files
+- load exact-version data contracts and validate type `implements` entries
+- expose deterministic contract and implementation digests
+- project and validate contract views when a record is accessed through an
+  implementation
 - validate embedded JSON Schema against the v0.3 profile
 - select explicit types and evaluate structured inferred match rules
 - validate raw frontmatter independently against every matched schema

--- a/README.md
+++ b/README.md
@@ -107,12 +107,12 @@ order_by:
 | Goal | Start here |
 | --- | --- |
 | Understand the model | [Overview](./00-overview.md) and [Concepts](./01-concepts.md) |
-| Create a collection | [Collection Layout](./02-collection-layout.md), [Configuration](./04-configuration.md), and [Type Files](./05-type-files.md) |
+| Create a collection | [Collection Layout](./02-collection-layout.md), [Configuration](./04-configuration.md), [Type Files](./05-type-files.md), and [Data Contracts](./05-data-contracts.md) |
 | Validate, query, or save views over records | [JSON Schema Profile](./06-json-schema-profile.md), [CEL Profile](./10-cel-profile.md), and [Querying](./11-querying.md) |
 | Add links or managed fields | [Links](./08-links.md) and [Lifecycle](./09-lifecycle.md) |
 | Define automation | [Runtime Contracts](./13-runtime-contracts.md) and [Workflows](./14-workflows.md) |
 | Migrate a v0.2 collection | [Migrations And Compatibility](./15-migrations-and-compatibility.md) |
-| Build a conforming tool | [Conformance](./16-conformance.md), [canonical schemas](./schemas/v0.3/), and [test fixtures](./tests/v0.3/) |
+| Build a conforming tool | [Conformance](./16-conformance.md), [data contracts](./05-data-contracts.md), [canonical schemas](./schemas/v0.3/), and [test fixtures](./tests/v0.3/) |
 
 ## Implementations
 
@@ -136,8 +136,8 @@ The specification is organized by topic:
 
 - Chapters 00–04 introduce the model, records, collection layout, and
   configuration.
-- Chapters 05–09 define types, schemas, collection semantics, links, and
-  lifecycle policy.
+- Chapters 05–09 and 05A define types, data contracts, schemas, collection
+  semantics, links, and lifecycle policy.
 - Chapters 10–12 define CEL expressions, queries, and record operations.
 - Chapters 13–14 define optional runtime contracts and workflows.
 - Chapters 15–16 cover migration, compatibility, and conformance.

--- a/examples/v0.3/tasknotes-migration/README.md
+++ b/examples/v0.3/tasknotes-migration/README.md
@@ -13,8 +13,10 @@ tooling and downstream package discussions.
 | `current-v0.2/mdbase.yaml` | representative current generated config |
 | `current-v0.2/_types/task.md` | representative old custom-field type |
 | `v0.3/mdbase.yaml` | v0.3 config shape |
+| `v0.3/_contracts/tasknotes.task.md` | exact TaskNotes data contract |
 | `v0.3/_types/meta.md` | v0.3 type wrapper metadata |
 | `v0.3/_types/task.md` | migrated v0.3 task type |
+| `v0.3/mdbase-pack.yaml` | transactional contract-and-type installation manifest |
 | `migration-report.json` | machine-readable explanation of the mapping |
 
 ## Important Moves
@@ -25,13 +27,14 @@ tooling and downstream package discussions.
   `collection.read_defaults`.
 - `generated` timestamps move to `lifecycle`.
 - `type: link` fields become string shapes plus `collection.links`.
-- TaskNotes semantic roles move from per-field `tn_role` to
-  `x-tasknotes.field_roles`.
+- TaskNotes semantic roles move from per-field `tn_role` to the type's
+  `implements[].fields` map.
 - Reminder variants use JSON Schema `oneOf` and `const`.
-- Archive semantics live in `x-tasknotes.archive`.
+- TaskNotes binding semantics validate against the contract's
+  `binding_schema`.
 
 ## Review Use
 
 This fixture should be used to test migration tooling before touching the
-TaskNotes generator. A future migrator should be able to produce the v0.3 type
-file plus a report very close to `migration-report.json`.
+TaskNotes generator. A future migrator should be able to produce the v0.3
+contract and type files plus a report very close to `migration-report.json`.

--- a/examples/v0.3/tasknotes-migration/migration-report.json
+++ b/examples/v0.3/tasknotes-migration/migration-report.json
@@ -26,7 +26,7 @@
   "mappings": [
     {
       "from": "fields.title",
-      "to": ["schema.value.properties.title", "x-tasknotes.field_roles.title"]
+      "to": ["schema.value.properties.title", "implements.0.fields.title"]
     },
     {
       "from": "fields.status.values",
@@ -34,11 +34,11 @@
     },
     {
       "from": "fields.status.default",
-      "to": ["schema.value.properties.status.default", "collection.read_defaults.status", "x-tasknotes.status.default"]
+      "to": ["schema.value.properties.status.default", "collection.read_defaults.status", "implements.0.binding.status.default"]
     },
     {
       "from": "fields.status.tn_completed_values",
-      "to": "x-tasknotes.status.completed_values"
+      "to": "implements.0.binding.status.completed_values"
     },
     {
       "from": "fields.dateCreated.generated",

--- a/examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md
+++ b/examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md
@@ -1,0 +1,95 @@
+---
+kind: mdbase.contract
+id: tasknotes.task
+version: 0.2.0
+name: TaskNotes task
+description: Portable task fields and binding semantics used by TaskNotes.
+
+schema:
+  dialect: json-schema-2020-12
+  value:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    type: object
+    required: [title, status, dateCreated]
+    additionalProperties: false
+    properties:
+      title: { type: string, minLength: 1 }
+      status: { type: string, minLength: 1 }
+      priority: { type: string }
+      due: { type: string, format: date }
+      scheduled: { type: string, format: date }
+      completedDate: { type: string, format: date }
+      tags:
+        type: array
+        items: { type: string }
+      contexts:
+        type: array
+        items: { type: string }
+      projects:
+        type: array
+        items: { type: string }
+      timeEstimate: { type: integer, minimum: 0 }
+      dateCreated: { type: string, format: date-time }
+      dateModified: { type: string, format: date-time }
+      recurrence: { type: string }
+      recurrenceAnchor: { type: string }
+      recurrenceParent: { type: string }
+      occurrenceDate: { type: string, format: date }
+      occurrenceMaterialization: { type: string }
+      occurrenceNextTrigger: { type: string }
+      occurrenceTemplate: { type: string }
+      occurrencePastHorizon: { type: string }
+      occurrenceFutureHorizon: { type: string }
+      completeInstances:
+        type: array
+        items: { type: string, format: date }
+      skippedInstances:
+        type: array
+        items: { type: string, format: date }
+      timeEntries:
+        type: array
+        items: { type: object }
+      blockedBy:
+        type: array
+        items: { type: object }
+      reminders:
+        type: array
+        items: { type: object }
+
+binding_schema:
+  dialect: json-schema-2020-12
+  value:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    type: object
+    required: [status]
+    additionalProperties: false
+    properties:
+      status:
+        type: object
+        required: [completed_values, default]
+        additionalProperties: false
+        properties:
+          completed_values:
+            type: array
+            minItems: 1
+            uniqueItems: true
+            items: { type: string }
+          default: { type: string }
+      priority:
+        type: object
+        required: [default]
+        additionalProperties: false
+        properties:
+          default: { type: string }
+      archive:
+        type: object
+        required: [archived_tag]
+        additionalProperties: false
+        properties:
+          archived_tag: { type: string, minLength: 1 }
+---
+
+# TaskNotes task
+
+This example contract is packaged with the migrated type. The TaskNotes
+specification owns the complete production contract.

--- a/examples/v0.3/tasknotes-migration/v0.3/_types/task.md
+++ b/examples/v0.3/tasknotes-migration/v0.3/_types/task.md
@@ -180,50 +180,50 @@ lifecycle:
     set:
       dateModified: { now: true }
 
-x-tasknotes:
-  contract: tasknotes.task
-  version: 1
-  field_roles:
-    title: title
-    status: status
-    priority: priority
-    due: due
-    scheduled: scheduled
-    completedDate: completedDate
-    tags: tags
-    contexts: contexts
-    projects: projects
-    timeEstimate: timeEstimate
-    dateCreated: dateCreated
-    dateModified: dateModified
-    recurrence: recurrence
-    recurrenceAnchor: recurrenceAnchor
-    recurrenceParent: recurrenceParent
-    occurrenceDate: occurrenceDate
-    occurrenceMaterialization: occurrenceMaterialization
-    occurrenceNextTrigger: occurrenceNextTrigger
-    occurrenceTemplate: occurrenceTemplate
-    occurrencePastHorizon: occurrencePastHorizon
-    occurrenceFutureHorizon: occurrenceFutureHorizon
-    completeInstances: completeInstances
-    skippedInstances: skippedInstances
-    timeEntries: timeEntries
-    blockedBy: blockedBy
-    reminders: reminders
-  status:
-    completed_values: [done, cancelled]
-    default: open
-  priority:
-    default: normal
-  archive:
-    tags_field: tags
-    archived_tag: archived
+implements:
+  - contract: tasknotes.task
+    version: 0.2.0
+    fields:
+      title: title
+      status: status
+      priority: priority
+      due: due
+      scheduled: scheduled
+      completedDate: completedDate
+      tags: tags
+      contexts: contexts
+      projects: projects
+      timeEstimate: timeEstimate
+      dateCreated: dateCreated
+      dateModified: dateModified
+      recurrence: recurrence
+      recurrenceAnchor: recurrenceAnchor
+      recurrenceParent: recurrenceParent
+      occurrenceDate: occurrenceDate
+      occurrenceMaterialization: occurrenceMaterialization
+      occurrenceNextTrigger: occurrenceNextTrigger
+      occurrenceTemplate: occurrenceTemplate
+      occurrencePastHorizon: occurrencePastHorizon
+      occurrenceFutureHorizon: occurrenceFutureHorizon
+      completeInstances: completeInstances
+      skippedInstances: skippedInstances
+      timeEntries: timeEntries
+      blockedBy: blockedBy
+      reminders: reminders
+    binding:
+      status:
+        completed_values: [done, cancelled]
+        default: open
+      priority:
+        default: normal
+      archive:
+        archived_tag: archived
 ---
 
 # Task
 
 Generated from TaskNotes settings. The JSON Schema section describes persisted
 frontmatter shape. The `collection` section describes mdbase-aware behavior.
-The `lifecycle` section describes managed writes. The `x-tasknotes` section
-describes TaskNotes semantics for tools that understand the TaskNotes task
-contract.
+The `lifecycle` section describes managed writes. The `implements` section maps
+the exact local `tasknotes.task` contract and carries schema-validated TaskNotes
+binding semantics.

--- a/examples/v0.3/tasknotes-migration/v0.3/mdbase-pack.yaml
+++ b/examples/v0.3/tasknotes-migration/v0.3/mdbase-pack.yaml
@@ -1,0 +1,14 @@
+kind: mdbase.type-pack
+id: tasknotes.tasks
+version: 0.2.0
+name: TaskNotes task support
+description: The TaskNotes data contract and its canonical task type.
+resources:
+  - kind: contract
+    source: _contracts/tasknotes.task.md
+    target: _contracts/tasknotes.task.md
+    digest: sha256:7e6b8ddb30982b88c71d5e14936f363b44185733082048487c0adcb6c1bc6787
+  - kind: type
+    source: _types/task.md
+    target: _types/task.md
+    digest: sha256:da2e044d3448c53dd2197e0ad1926fd6c797eb5810bfc896e3eda81203b94b74

--- a/examples/v0.3/tasknotes-migration/v0.3/mdbase.yaml
+++ b/examples/v0.3/tasknotes-migration/v0.3/mdbase.yaml
@@ -4,8 +4,8 @@ description: "Task collection managed by TaskNotes for Obsidian"
 
 settings:
   types_folder: "_types"
+  contracts_folder: "_contracts"
   record_extensions: [md]
   validation: warn
   explicit_type_keys: [type, types]
   id_field: id
-

--- a/packages/runtime-contracts/scripts/generate-schema-module.mjs
+++ b/packages/runtime-contracts/scripts/generate-schema-module.mjs
@@ -13,6 +13,8 @@ const schemaPaths = {
   recordDocument: "record-document.schema.json",
   queryResult: "query-result.schema.json",
   typeFile: "type-file.schema.json",
+  dataContract: "data-contract.schema.json",
+  typePack: "type-pack.schema.json",
   provider: "runtime/provider.schema.json",
   action: "runtime/action.schema.json",
   event: "runtime/event.schema.json",

--- a/packages/runtime-contracts/src/canonical-schemas.ts
+++ b/packages/runtime-contracts/src/canonical-schemas.ts
@@ -11,6 +11,8 @@ export interface CanonicalSchemas {
   recordDocument: Record<string, unknown>;
   queryResult: Record<string, unknown>;
   typeFile: Record<string, unknown>;
+  dataContract: Record<string, unknown>;
+  typePack: Record<string, unknown>;
   provider: Record<string, unknown>;
   action: Record<string, unknown>;
   event: Record<string, unknown>;

--- a/packages/runtime-contracts/src/generated-schemas.ts
+++ b/packages/runtime-contracts/src/generated-schemas.ts
@@ -32,6 +32,10 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
             "type": "string",
             "minLength": 1
           },
+          "contracts_folder": {
+            "type": "string",
+            "minLength": 1
+          },
           "record_extensions": {
             "type": "array",
             "minItems": 1,
@@ -673,6 +677,9 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
       "body": {
         "type": "string"
       },
+      "document": {
+        "type": "string"
+      },
       "file": {
         "type": "object",
         "required": [
@@ -877,6 +884,9 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
       },
       "migrations": {
         "$ref": "#/$defs/migrations"
+      },
+      "implements": {
+        "$ref": "#/$defs/implementations"
       }
     },
     "patternProperties": {
@@ -1441,6 +1451,57 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
           "additionalProperties": false
         }
       },
+      "implementations": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "$ref": "#/$defs/implementation"
+        }
+      },
+      "implementation": {
+        "type": "object",
+        "required": [
+          "contract",
+          "version",
+          "fields"
+        ],
+        "properties": {
+          "contract": {
+            "$ref": "#/$defs/contractId"
+          },
+          "version": {
+            "$ref": "#/$defs/semanticVersion"
+          },
+          "fields": {
+            "type": "object",
+            "propertyNames": {
+              "$ref": "#/$defs/fieldPath"
+            },
+            "additionalProperties": {
+              "$ref": "#/$defs/fieldPath"
+            }
+          },
+          "binding": {
+            "type": "object"
+          }
+        },
+        "patternProperties": {
+          "^x-[A-Za-z][A-Za-z0-9._:-]{0,127}$": {
+            "$ref": "#/$defs/domainExtension"
+          }
+        },
+        "additionalProperties": false
+      },
+      "contractId": {
+        "type": "string",
+        "minLength": 3,
+        "maxLength": 128,
+        "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+      },
+      "semanticVersion": {
+        "type": "string",
+        "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+      },
       "expression": {
         "type": "object",
         "required": [
@@ -1466,6 +1527,189 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
           "boolean",
           "null"
         ]
+      }
+    }
+  },
+  "dataContract": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://mdbase.dev/schemas/v0.3/data-contract.schema.json",
+    "title": "mdbase v0.3 data contract frontmatter",
+    "type": "object",
+    "required": [
+      "kind",
+      "id",
+      "version",
+      "schema"
+    ],
+    "properties": {
+      "kind": {
+        "const": "mdbase.contract"
+      },
+      "id": {
+        "$ref": "#/$defs/contractId"
+      },
+      "version": {
+        "$ref": "#/$defs/semanticVersion"
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": {
+        "type": "string"
+      },
+      "schema": {
+        "$ref": "#/$defs/schemaWrapper"
+      },
+      "binding_schema": {
+        "$ref": "#/$defs/schemaWrapper"
+      }
+    },
+    "patternProperties": {
+      "^x-[A-Za-z][A-Za-z0-9._:-]{0,127}$": true
+    },
+    "additionalProperties": false,
+    "$defs": {
+      "contractId": {
+        "type": "string",
+        "minLength": 3,
+        "maxLength": 128,
+        "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+      },
+      "semanticVersion": {
+        "type": "string",
+        "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+      },
+      "schemaWrapper": {
+        "type": "object",
+        "required": [
+          "dialect"
+        ],
+        "properties": {
+          "dialect": {
+            "const": "json-schema-2020-12"
+          },
+          "value": {
+            "type": "object"
+          },
+          "ref": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "oneOf": [
+          {
+            "required": [
+              "value"
+            ],
+            "not": {
+              "required": [
+                "ref"
+              ]
+            }
+          },
+          {
+            "required": [
+              "ref"
+            ],
+            "not": {
+              "required": [
+                "value"
+              ]
+            }
+          }
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "typePack": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://mdbase.dev/schemas/v0.3/type-pack.schema.json",
+    "title": "mdbase v0.3 type pack manifest",
+    "type": "object",
+    "required": [
+      "kind",
+      "id",
+      "version",
+      "resources"
+    ],
+    "properties": {
+      "kind": {
+        "const": "mdbase.type-pack"
+      },
+      "id": {
+        "$ref": "#/$defs/packId"
+      },
+      "version": {
+        "$ref": "#/$defs/semanticVersion"
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": {
+        "type": "string"
+      },
+      "resources": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "$ref": "#/$defs/resource"
+        }
+      }
+    },
+    "patternProperties": {
+      "^x-[A-Za-z][A-Za-z0-9._:-]{0,127}$": true
+    },
+    "additionalProperties": false,
+    "$defs": {
+      "packId": {
+        "type": "string",
+        "minLength": 3,
+        "maxLength": 128,
+        "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+      },
+      "semanticVersion": {
+        "type": "string",
+        "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+      },
+      "safeRelativePath": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\).+$"
+      },
+      "digest": {
+        "type": "string",
+        "pattern": "^sha256:[0-9a-f]{64}$"
+      },
+      "resource": {
+        "type": "object",
+        "required": [
+          "kind",
+          "source",
+          "target",
+          "digest"
+        ],
+        "properties": {
+          "kind": {
+            "enum": [
+              "contract",
+              "type",
+              "schema"
+            ]
+          },
+          "source": {
+            "$ref": "#/$defs/safeRelativePath"
+          },
+          "target": {
+            "$ref": "#/$defs/safeRelativePath"
+          },
+          "digest": {
+            "$ref": "#/$defs/digest"
+          }
+        },
+        "additionalProperties": false
       }
     }
   },

--- a/packages/runtime-contracts/src/generated-schemas.ts
+++ b/packages/runtime-contracts/src/generated-schemas.ts
@@ -1602,20 +1602,18 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
             "required": [
               "value"
             ],
-            "not": {
-              "required": [
-                "ref"
-              ]
+            "properties": {
+              "value": true,
+              "ref": false
             }
           },
           {
             "required": [
               "ref"
             ],
-            "not": {
-              "required": [
-                "value"
-              ]
+            "properties": {
+              "ref": true,
+              "value": false
             }
           }
         ],

--- a/packages/runtime-contracts/src/host.ts
+++ b/packages/runtime-contracts/src/host.ts
@@ -305,7 +305,7 @@ export class InMemoryRuntimeHost implements RuntimeHost {
       );
       const key = `${contract.type}:${contract.id}`;
       if (ids.has(key)) {
-        throw new RuntimeHostError("contract_conflict", `Provider ${descriptor.id} repeats ${key}.`);
+        throw new RuntimeHostError("runtime_contract_conflict", `Provider ${descriptor.id} repeats ${key}.`);
       }
       ids.add(key);
       if (
@@ -316,10 +316,10 @@ export class InMemoryRuntimeHost implements RuntimeHost {
         throw new RuntimeHostError("provider_contract_mismatch", `${contract.id} names provider ${String(contract.provider)}.`);
       }
       if (contract.type === "action" && this.actionOwners.has(contract.id)) {
-        throw new RuntimeHostError("contract_conflict", `Action ${contract.id} is already registered.`);
+        throw new RuntimeHostError("runtime_contract_conflict", `Action ${contract.id} is already registered.`);
       }
       if (contract.type === "event" && this.eventOwners.has(contract.id)) {
-        throw new RuntimeHostError("contract_conflict", `Event ${contract.id} is already registered.`);
+        throw new RuntimeHostError("runtime_contract_conflict", `Event ${contract.id} is already registered.`);
       }
     }
     assertAdvertisedContracts(descriptor, contracts, "actions", "action");
@@ -381,7 +381,7 @@ export class InMemoryRuntimeHost implements RuntimeHost {
       event.contract_version !== contract.version ||
       (event.source.provider !== undefined && event.source.provider !== providerId)
     ) {
-      this.rejectEvent("contract_version_mismatch", `Event ${event.type} does not match its registered contract.`, providerId, event.type);
+      this.rejectEvent("runtime_contract_version_mismatch", `Event ${event.type} does not match its registered contract.`, providerId, event.type);
       return;
     }
     if (this.recentEventIds.has(event.id)) return;

--- a/packages/runtime-contracts/src/schemas.ts
+++ b/packages/runtime-contracts/src/schemas.ts
@@ -34,6 +34,8 @@ export async function loadCanonicalSchemas(schemaRoot?: string): Promise<Canonic
     recordDocument: await readJson(join(schemaRoot, "record-document.schema.json")),
     queryResult: await readJson(join(schemaRoot, "query-result.schema.json")),
     typeFile: await readJson(join(schemaRoot, "type-file.schema.json")),
+    dataContract: await readJson(join(schemaRoot, "data-contract.schema.json")),
+    typePack: await readJson(join(schemaRoot, "type-pack.schema.json")),
     provider: await readJson(join(schemaRoot, "runtime/provider.schema.json")),
     action: await readJson(join(schemaRoot, "runtime/action.schema.json")),
     event: await readJson(join(schemaRoot, "runtime/event.schema.json")),

--- a/packages/runtime-contracts/src/validator.ts
+++ b/packages/runtime-contracts/src/validator.ts
@@ -287,7 +287,7 @@ export class RuntimeContractValidator {
     if (contractVersion !== contract.version) {
       diagnostics.push({
         severity: "error",
-        code: "contract_version_mismatch",
+        code: "runtime_contract_version_mismatch",
         message: `Event ${eventType} declares contract version ${String(contractVersion)}, but the registry provides ${String(contract.version)}.`,
         id: eventType,
         details: {
@@ -429,7 +429,7 @@ export class RuntimeContractValidator {
       }
       registry.diagnostics.push({
         severity: "error",
-        code: "contract_conflict",
+        code: "runtime_contract_conflict",
         message: `Conflicting ${contract.type} contract ${contract.id}.`,
         path: record.path,
         id: contract.id,

--- a/packages/runtime-contracts/test/canvas-runtime.test.mjs
+++ b/packages/runtime-contracts/test/canvas-runtime.test.mjs
@@ -55,7 +55,7 @@ test("validates event envelopes and evaluated action inputs", async () => {
     validator.validateEventEnvelope(registry, {
       ...eventEnvelope,
       contract_version: 2
-    }).diagnostics.some((diagnostic) => diagnostic.code === "contract_version_mismatch"),
+    }).diagnostics.some((diagnostic) => diagnostic.code === "runtime_contract_version_mismatch"),
     true
   );
   assert.equal(
@@ -108,10 +108,10 @@ test("coalesces identical contracts and rejects conflicting copies", async () =>
   assert.ok(action);
 
   const coalesced = validator.composeRegistry(loaded, [{ ...action }]);
-  assert.equal(coalesced.diagnostics.some((diagnostic) => diagnostic.code === "contract_conflict"), false);
+  assert.equal(coalesced.diagnostics.some((diagnostic) => diagnostic.code === "runtime_contract_conflict"), false);
 
   const conflicted = validator.composeRegistry(loaded, [{ ...action, version: 2 }]);
-  assert.equal(conflicted.diagnostics.some((diagnostic) => diagnostic.code === "contract_conflict"), true);
+  assert.equal(conflicted.diagnostics.some((diagnostic) => diagnostic.code === "runtime_contract_conflict"), true);
 });
 
 test("checks provider requirements against provider implementation versions", async () => {

--- a/packages/runtime-contracts/test/host.test.mjs
+++ b/packages/runtime-contracts/test/host.test.mjs
@@ -260,6 +260,8 @@ test("host-owned policy resolvers refresh authorization without replacing provid
 
 test("main package export is browser-safe", async () => {
   const schemas = getCanonicalSchemas();
+  assert.equal(typeof schemas.dataContract.$id, "string");
+  assert.equal(typeof schemas.typePack.$id, "string");
   assert.equal(
     schemas.provider.$id,
     "https://mdbase.dev/schemas/runtime/v0.1/provider.schema.json",

--- a/release/v0.3.0-operator-guide.md
+++ b/release/v0.3.0-operator-guide.md
@@ -55,7 +55,27 @@ files. After recovery, reinstall the prior consumer versions and validate the
 restored v0.2 collection. Do not delete the backup until the migrated collection
 has passed its full application smoke tests.
 
-## Author a provider
+## Author a data contract
+
+Define the passive record interface first:
+
+1. create an exact-version `mdbase.contract` file under `_contracts/`
+2. express its normalized record view and optional binding with JSON Schema
+   2020-12
+3. add a type-local `implements` entry with direct field mappings
+4. validate the type, binding, and representative contract projections
+5. package the contract, implementing types, auxiliary types, and referenced
+   schemas in one `mdbase.type-pack`
+
+Do not put discovery metadata in `x-*`. Do not grant access merely because a
+type implements the contract. A gateway approval names the exact implementing
+types and digests it is granting, while record creation selects one exact type.
+
+Install packs through a staged, validated transaction. An invalid contract,
+binding, type, digest, existing record, or target conflict must leave the live
+collection unchanged.
+
+## Author a runtime provider
 
 Import generic types from the browser-safe package, not from TaskNotes or a
 platform adapter:

--- a/release/v0.3.0.md
+++ b/release/v0.3.0.md
@@ -21,9 +21,10 @@ multi-platform CI, and live Obsidian smoke evidence.
 
 ### Collection Protocol
 
-`mdbase-spec` owns the normative collection protocol, canonical schemas,
-profile identifiers, conformance fixtures, and migration rules. Implementations
-consume those artifacts; they do not redefine them.
+`mdbase-spec` owns the normative collection protocol, canonical type, data
+contract, and type-pack schemas, profile identifiers, conformance fixtures, and
+migration rules. Implementations consume those artifacts; they do not redefine
+them.
 
 The `mdbase-dev/mdbase.dev` repository owns the ecosystem website and its
 deployment cadence. It imports the versioned specification reader built here;
@@ -100,12 +101,12 @@ passes preflight.
 | `mdbase-spec` | normative prose, schemas, fixtures, migration rules | all artifact and site gates | source of truth |
 | `@callumalpass/mdbase-runtime` | portable contracts and reference host | `runtime_contracts/0.1`; browser package smoke | no TaskNotes/Obsidian/Node dependency in main export |
 | `mdbase-runtime-contracts-rs` | independent runtime contract validation harness | canonical schema, example collection, and embedded-schema tests | consume the same versioned artifacts as the TypeScript runtime package |
-| `@callumalpass/mdbase` | TypeScript collection implementation | `core_read`, `collection_semantics`, `cel`, `cel_query`, `links`, `core_write`, `lifecycle` | exact compatible spec artifacts |
+| `@callumalpass/mdbase` | TypeScript collection and data-contract implementation | `core_read`, `collection_semantics`, `cel`, `cel_query`, `links`, `core_write`, `lifecycle` | exact compatible spec artifacts |
 | `mdbase-cli` | safe user-facing operations and migration | installed-tarball suite and v0.2 migration rehearsals | publish after TypeScript core |
 | `mdbase-rs` | independent Rust collection implementation and separately versioned workflow engine | `core_read`, `collection_semantics`, `cel`, `cel_match`, `cel_query`, `links`, `core_write`, `lifecycle`, `runtime_contracts/0.1`, `watch`; workflow execution remains separately evidenced | claim only verified profiles per artifact |
 | `mdbase-lsp` | editor diagnostics from Rust semantics | Rust claim plus LSP diagnostic fixtures | no independent schema dialect |
 | `mdbase-obsidian` | selected Obsidian host adapter and collection UI | shared-host, unload, and provider-discovery smoke tests | owns one generic host per loaded vault |
-| `@tasknotes/model` | TaskNotes domain types and provider metadata | ESM/CJS package smoke | generic runtime types come from mdbase runtime package |
+| `@tasknotes/model` | TaskNotes data contract, type pack, domain types, and provider metadata | contract conformance plus ESM/CJS package smoke | generic runtime types come from mdbase runtime package |
 | TaskNotes | `tasknotes` provider and domain operations | provider contract, dispatch, event, authorization tests | may host only through generic adapter |
 | TaskNotes Workflows | workflow executor and TaskNotes integrations | canonical file generation, legacy migration, registration, policy, and dispatch tests | runtime host is injected, not TaskNotes-owned |
 | Canvas Bases | `canvas-bases` provider and `canvas.drop` event | works without TaskNotes; cross-plugin workflow smoke | TaskNotes integration is optional |
@@ -115,8 +116,10 @@ passes preflight.
 
 ### Specification
 
-- [x] No unresolved normative questions in chapters 00-16.
+- [x] No unresolved normative questions in chapters 00-16 or Chapter 05A.
 - [x] Every canonical schema validates as Draft 2020-12.
+- [x] Data contract, implementation, projection, conflict, digest, and type-pack
+      fixtures are executable.
 - [x] Conformance claims validate against the canonical claim schema.
 - [x] Examples and migration fixtures are generated or checked reproducibly.
 - [x] The promoted site and archived v0.2 documentation both build.
@@ -175,7 +178,7 @@ Evidence collected through 2026-07-19 in Linux x86_64:
 
 | Surface | Result |
 | --- | --- |
-| v0.3 artifact suite | 36 executable and 89 adapter-target cases pass |
+| v0.3 artifact suite | 51 executable and 93 adapter-target cases pass |
 | conformance claims | TypeScript and Rust claims validate against the canonical schema |
 | TypeScript core | build and all 1,939 tests pass, including stable-marker and retained alpha-marker compatibility |
 | CLI | 265 tests pass, including init, analyzed migration, apply, recovery, stale reports, and partial policy |

--- a/schemas/v0.3/README.md
+++ b/schemas/v0.3/README.md
@@ -10,6 +10,8 @@ yet published package artifacts.
 | Schema | Purpose |
 | --- | --- |
 | `type-file.schema.json` | frontmatter of `_types/*.md` v0.3 type files |
+| `data-contract.schema.json` | frontmatter of `_contracts/*.md` data contract files |
+| `type-pack.schema.json` | transactional type-pack manifests |
 | `query.schema.json` | portable query input objects |
 | `query-result.schema.json` | query results plus optional context, view, grouping, and summary metadata |
 | `record-document.schema.json` | complete authoritative record documents returned by read and successful mutations |

--- a/schemas/v0.3/config.schema.json
+++ b/schemas/v0.3/config.schema.json
@@ -27,6 +27,10 @@
           "type": "string",
           "minLength": 1
         },
+        "contracts_folder": {
+          "type": "string",
+          "minLength": 1
+        },
         "record_extensions": {
           "type": "array",
           "minItems": 1,

--- a/schemas/v0.3/data-contract.schema.json
+++ b/schemas/v0.3/data-contract.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/v0.3/data-contract.schema.json",
+  "title": "mdbase v0.3 data contract frontmatter",
+  "type": "object",
+  "required": ["kind", "id", "version", "schema"],
+  "properties": {
+    "kind": {
+      "const": "mdbase.contract"
+    },
+    "id": {
+      "$ref": "#/$defs/contractId"
+    },
+    "version": {
+      "$ref": "#/$defs/semanticVersion"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string"
+    },
+    "schema": {
+      "$ref": "#/$defs/schemaWrapper"
+    },
+    "binding_schema": {
+      "$ref": "#/$defs/schemaWrapper"
+    }
+  },
+  "patternProperties": {
+    "^x-[A-Za-z][A-Za-z0-9._:-]{0,127}$": true
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "contractId": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 128,
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+    },
+    "semanticVersion": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+    },
+    "schemaWrapper": {
+      "type": "object",
+      "required": ["dialect"],
+      "properties": {
+        "dialect": {
+          "const": "json-schema-2020-12"
+        },
+        "value": {
+          "type": "object"
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "oneOf": [
+        {
+          "required": ["value"],
+          "not": {
+            "required": ["ref"]
+          }
+        },
+        {
+          "required": ["ref"],
+          "not": {
+            "required": ["value"]
+          }
+        }
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/v0.3/data-contract.schema.json
+++ b/schemas/v0.3/data-contract.schema.json
@@ -61,14 +61,16 @@
       "oneOf": [
         {
           "required": ["value"],
-          "not": {
-            "required": ["ref"]
+          "properties": {
+            "value": true,
+            "ref": false
           }
         },
         {
           "required": ["ref"],
-          "not": {
-            "required": ["value"]
+          "properties": {
+            "ref": true,
+            "value": false
           }
         }
       ],

--- a/schemas/v0.3/type-file.schema.json
+++ b/schemas/v0.3/type-file.schema.json
@@ -35,6 +35,9 @@
     },
     "migrations": {
       "$ref": "#/$defs/migrations"
+    },
+    "implements": {
+      "$ref": "#/$defs/implementations"
     }
   },
   "patternProperties": {
@@ -544,6 +547,53 @@
         ],
         "additionalProperties": false
       }
+    },
+    "implementations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/implementation"
+      }
+    },
+    "implementation": {
+      "type": "object",
+      "required": ["contract", "version", "fields"],
+      "properties": {
+        "contract": {
+          "$ref": "#/$defs/contractId"
+        },
+        "version": {
+          "$ref": "#/$defs/semanticVersion"
+        },
+        "fields": {
+          "type": "object",
+          "propertyNames": {
+            "$ref": "#/$defs/fieldPath"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/fieldPath"
+          }
+        },
+        "binding": {
+          "type": "object"
+        }
+      },
+      "patternProperties": {
+        "^x-[A-Za-z][A-Za-z0-9._:-]{0,127}$": {
+          "$ref": "#/$defs/domainExtension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "contractId": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 128,
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+    },
+    "semanticVersion": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
     },
     "expression": {
       "type": "object",

--- a/schemas/v0.3/type-pack.schema.json
+++ b/schemas/v0.3/type-pack.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/v0.3/type-pack.schema.json",
+  "title": "mdbase v0.3 type pack manifest",
+  "type": "object",
+  "required": ["kind", "id", "version", "resources"],
+  "properties": {
+    "kind": {
+      "const": "mdbase.type-pack"
+    },
+    "id": {
+      "$ref": "#/$defs/packId"
+    },
+    "version": {
+      "$ref": "#/$defs/semanticVersion"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string"
+    },
+    "resources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/resource"
+      }
+    }
+  },
+  "patternProperties": {
+    "^x-[A-Za-z][A-Za-z0-9._:-]{0,127}$": true
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "packId": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 128,
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+    },
+    "semanticVersion": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+    },
+    "safeRelativePath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\).+$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "resource": {
+      "type": "object",
+      "required": ["kind", "source", "target", "digest"],
+      "properties": {
+        "kind": {
+          "enum": ["contract", "type", "schema"]
+        },
+        "source": {
+          "$ref": "#/$defs/safeRelativePath"
+        },
+        "target": {
+          "$ref": "#/$defs/safeRelativePath"
+        },
+        "digest": {
+          "$ref": "#/$defs/digest"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/scripts/check_v03_tests.py
+++ b/scripts/check_v03_tests.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import glob
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -50,6 +51,11 @@ EXECUTABLE_OPERATIONS = {
     "json_document_valid",
     "inspect_yaml",
     "migrate_type",
+    "type_pack_resources_validate",
+    "data_contract_implementation_validate",
+    "data_contract_digest",
+    "data_contract_implementation_digest",
+    "data_contract_registry_validate",
 }
 
 CONFORMANCE_PROFILES = {
@@ -292,26 +298,31 @@ def validate_suite_shape(
 
 def validate_setup_artifacts(path: Path, group: dict[str, Any], errors: list[str]) -> None:
     setup = group.get("setup") or {}
-    types = setup.get("types") or {}
-    if not isinstance(types, dict):
-        errors.append(f"{path}: group {group.get('name')!r} setup.types must be a mapping")
-        return
-    for file_name, content in types.items():
-        if not isinstance(content, str):
-            errors.append(f"{path}: setup type {file_name} content must be a string")
+    for artifact_kind, identity_key in (("types", "name"), ("contracts", "id")):
+        artifacts = setup.get(artifact_kind) or {}
+        if not isinstance(artifacts, dict):
+            errors.append(
+                f"{path}: group {group.get('name')!r} setup.{artifact_kind} must be a mapping"
+            )
             continue
-        label = f"{path}: setup type {file_name}"
-        try:
-            if str(file_name).endswith(".md"):
-                frontmatter = parse_markdown_frontmatter_text(content, label)
-                if not isinstance(frontmatter.get("name"), str) or not frontmatter["name"]:
-                    errors.append(f"{label}: missing non-empty frontmatter name")
-            elif str(file_name).endswith(".json"):
-                parsed = json.loads(content)
-                if not isinstance(parsed, dict):
-                    errors.append(f"{label}: JSON schema fixture must be an object")
-        except (ValueError, json.JSONDecodeError, yaml.YAMLError) as error:
-            errors.append(f"{label}: {error}")
+        for file_name, content in artifacts.items():
+            if not isinstance(content, str):
+                errors.append(f"{path}: setup {artifact_kind} {file_name} content must be a string")
+                continue
+            label = f"{path}: setup {artifact_kind} {file_name}"
+            try:
+                if str(file_name).endswith(".md"):
+                    frontmatter = parse_markdown_frontmatter_text(content, label)
+                    if not isinstance(frontmatter.get(identity_key), str) or not frontmatter[identity_key]:
+                        errors.append(
+                            f"{label}: missing non-empty frontmatter {identity_key}"
+                        )
+                elif str(file_name).endswith(".json"):
+                    parsed = json.loads(content)
+                    if not isinstance(parsed, dict):
+                        errors.append(f"{label}: JSON schema fixture must be an object")
+            except (ValueError, json.JSONDecodeError, yaml.YAMLError) as error:
+                errors.append(f"{label}: {error}")
 
 
 def run_executable_test(test: dict[str, Any], setup: dict[str, Any] | None = None) -> None:
@@ -335,10 +346,12 @@ def run_executable_test(test: dict[str, Any], setup: dict[str, Any] | None = Non
         return
 
     if operation == "embedded_json_schema_validate":
-        pointer = input_data.get("pointer", "/schema/value")
+        pointers = input_data.get("pointers") or [input_data.get("pointer", "/schema/value")]
         for path in expand_paths(input_data.get("paths", [])):
-            embedded = get_pointer(load_markdown_frontmatter(path), pointer)
-            Draft202012Validator.check_schema(embedded)
+            frontmatter = load_markdown_frontmatter(path)
+            for pointer in pointers:
+                embedded = get_pointer(frontmatter, pointer)
+                Draft202012Validator.check_schema(embedded)
         assert_valid(expect)
         return
 
@@ -375,6 +388,51 @@ def run_executable_test(test: dict[str, Any], setup: dict[str, Any] | None = Non
 
     if operation == "migrate_type":
         run_migrate_type_test(input_data, expect, setup)
+        return
+
+    if operation == "type_pack_resources_validate":
+        run_type_pack_resources_test(input_data, expect)
+        return
+
+    if operation == "data_contract_implementation_validate":
+        run_data_contract_implementation_test(input_data, expect)
+        return
+
+    if operation == "data_contract_digest":
+        contract = load_markdown_frontmatter(input_data["contract"])
+        actual = data_contract_digest(contract)
+        if expect.get("digest") != actual:
+            raise AssertionError(f"expected digest {expect.get('digest')!r}, got {actual!r}")
+        return
+
+    if operation == "data_contract_implementation_digest":
+        contract = load_markdown_frontmatter(input_data["contract"])
+        type_file = load_markdown_frontmatter(input_data["type"])
+        matching = [
+            entry
+            for entry in type_file.get("implements", []) or []
+            if entry.get("contract") == contract.get("id")
+            and entry.get("version") == contract.get("version")
+        ]
+        if len(matching) != 1:
+            raise AssertionError("type must have one exact implementation")
+        actual = data_contract_implementation_digest(contract, type_file, matching[0])
+        if expect.get("digest") != actual:
+            raise AssertionError(f"expected digest {expect.get('digest')!r}, got {actual!r}")
+        return
+
+    if operation == "data_contract_registry_validate":
+        failures: list[str] = []
+        registry: dict[tuple[str, str], str] = {}
+        for contract_path in expand_paths(input_data.get("paths", [])):
+            contract = load_markdown_frontmatter(contract_path)
+            key = (contract.get("id"), contract.get("version"))
+            digest = data_contract_digest(contract)
+            existing = registry.get(key)
+            if existing is not None and existing != digest:
+                failures.append(f"data contract conflict for {key[0]}@{key[1]}")
+            registry[key] = digest
+        assert_expected_validation_result(failures, expect)
         return
 
     raise AssertionError(f"unsupported operation: {operation}")
@@ -417,6 +475,187 @@ def run_migrate_type_test(input_data: dict[str, Any], expect: dict[str, Any], se
         raise AssertionError("detected_generator mismatch")
     if subset := expect.get("report_contains"):
         assert_subset(report, subset)
+
+
+def run_type_pack_resources_test(input_data: dict[str, Any], expect: dict[str, Any]) -> None:
+    manifest_path = resolve(input_data["path"])
+    manifest = load_yaml(manifest_path)
+    failures: list[str] = []
+    seen_targets: set[str] = set()
+
+    for resource in manifest.get("resources", []) or []:
+        source = resource.get("source")
+        target = resource.get("target")
+        declared = resource.get("digest")
+        if not isinstance(source, str) or not isinstance(target, str) or not isinstance(declared, str):
+            failures.append("resource is missing source, target, or digest")
+            continue
+        if target in seen_targets:
+            failures.append(f"duplicate target: {target}")
+        seen_targets.add(target)
+        source_path = (manifest_path.parent / source).resolve()
+        try:
+            source_path.relative_to(manifest_path.parent.resolve())
+        except ValueError:
+            failures.append(f"source escapes pack root: {source}")
+            continue
+        if not source_path.is_file():
+            failures.append(f"source does not exist: {source}")
+            continue
+        actual = "sha256:" + hashlib.sha256(source_path.read_bytes()).hexdigest()
+        if actual != declared:
+            failures.append(f"digest mismatch for {source}: expected {declared}, got {actual}")
+
+    assert_expected_validation_result(failures, expect)
+
+
+def run_data_contract_implementation_test(
+    input_data: dict[str, Any], expect: dict[str, Any]
+) -> None:
+    failures: list[str] = []
+    contract = load_markdown_frontmatter(input_data["contract"])
+    type_file = load_markdown_frontmatter(input_data["type"])
+
+    contract_meta = Draft202012Validator(load_json("schemas/v0.3/data-contract.schema.json"))
+    type_meta = Draft202012Validator(load_json("schemas/v0.3/type-file.schema.json"))
+    failures.extend(error.message for error in contract_meta.iter_errors(contract))
+    failures.extend(error.message for error in type_meta.iter_errors(type_file))
+    if failures:
+        assert_expected_validation_result(failures, expect)
+        return
+
+    contract_schema = get_pointer(contract, "/schema/value")
+    Draft202012Validator.check_schema(contract_schema)
+    binding_schema = contract.get("binding_schema", {}).get("value")
+    if binding_schema is not None:
+        Draft202012Validator.check_schema(binding_schema)
+
+    matching = [
+        entry
+        for entry in type_file.get("implements", []) or []
+        if entry.get("contract") == contract.get("id")
+        and entry.get("version") == contract.get("version")
+    ]
+    if len(matching) != 1:
+        failures.append(
+            "type must contain exactly one implementation for the contract ID and version"
+        )
+        assert_expected_validation_result(failures, expect)
+        return
+
+    implementation = matching[0]
+    fields = implementation.get("fields") or {}
+    required = contract_schema.get("required") or []
+    for field_name in required:
+        if field_name not in fields:
+            failures.append(f"required contract field is not mapped: {field_name}")
+
+    for contract_field, record_field in fields.items():
+        if not schema_declares_field(contract_schema, contract_field):
+            failures.append(f"contract field is not declared: {contract_field}")
+        type_schema = get_pointer(type_file, "/schema/value")
+        if not schema_declares_field(type_schema, record_field):
+            failures.append(f"record field is not declared: {record_field}")
+
+    binding = implementation.get("binding") or {}
+    if binding_schema is None:
+        if binding:
+            failures.append("binding is non-empty but contract has no binding_schema")
+    else:
+        failures.extend(
+            f"binding: {error.message}"
+            for error in Draft202012Validator(binding_schema).iter_errors(binding)
+        )
+
+    record_path = input_data.get("record")
+    if record_path and not failures:
+        record_path = resolve(record_path)
+        if record_path.suffix.lower() == ".md":
+            record = load_markdown_frontmatter(record_path)
+        else:
+            record = load_yaml(record_path)
+        view = {
+            contract_field: record[record_field]
+            for contract_field, record_field in fields.items()
+            if "." not in contract_field
+            and "[]" not in contract_field
+            and "." not in record_field
+            and "[]" not in record_field
+            and record_field in record
+        }
+        failures.extend(
+            f"record: {error.message}"
+            for error in Draft202012Validator(contract_schema).iter_errors(view)
+        )
+
+    assert_expected_validation_result(failures, expect)
+
+
+def data_contract_digest(contract: dict[str, Any]) -> str:
+    payload = {
+        key: contract[key]
+        for key in ("kind", "id", "version", "schema", "binding_schema")
+        if key in contract
+    }
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def data_contract_implementation_digest(
+    contract: dict[str, Any],
+    type_file: dict[str, Any],
+    implementation: dict[str, Any],
+) -> str:
+    type_semantics = {
+        key: type_file[key]
+        for key in ("name", "version", "match", "schema", "collection", "lifecycle")
+        if key in type_file
+    }
+    payload = {
+        "contract_digest": data_contract_digest(contract),
+        "type": type_semantics,
+        "implementation": implementation,
+    }
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def schema_declares_field(schema: dict[str, Any], field_path: str) -> bool:
+    current: Any = schema
+    for part in field_path.replace("[]", "").split("."):
+        properties = current.get("properties") if isinstance(current, dict) else None
+        if not isinstance(properties, dict) or part not in properties:
+            return False
+        current = properties[part]
+        if "[]" in field_path and isinstance(current, dict) and "items" in current:
+            current = current["items"]
+    return True
+
+
+def assert_expected_validation_result(failures: list[str], expect: dict[str, Any]) -> None:
+    if expect.get("valid") is False:
+        if not failures:
+            raise AssertionError("expected validation to fail")
+        expected_contains = expect.get("error_contains")
+        if expected_contains and not any(expected_contains in failure for failure in failures):
+            raise AssertionError(
+                f"expected an error containing {expected_contains!r}, got {failures!r}"
+            )
+        return
+    if failures:
+        raise AssertionError("; ".join(failures))
 
 
 def assert_subset(actual: Any, expected_subset: Any) -> None:

--- a/scripts/check_v03_tests.py
+++ b/scripts/check_v03_tests.py
@@ -52,6 +52,7 @@ EXECUTABLE_OPERATIONS = {
     "inspect_yaml",
     "migrate_type",
     "type_pack_resources_validate",
+    "install_type_pack",
     "data_contract_implementation_validate",
     "data_contract_digest",
     "data_contract_implementation_digest",
@@ -394,6 +395,10 @@ def run_executable_test(test: dict[str, Any], setup: dict[str, Any] | None = Non
         run_type_pack_resources_test(input_data, expect)
         return
 
+    if operation == "install_type_pack":
+        run_install_type_pack_test(input_data, expect, setup)
+        return
+
     if operation == "data_contract_implementation_validate":
         run_data_contract_implementation_test(input_data, expect)
         return
@@ -509,6 +514,110 @@ def run_type_pack_resources_test(input_data: dict[str, Any], expect: dict[str, A
     assert_expected_validation_result(failures, expect)
 
 
+def run_install_type_pack_test(
+    input_data: dict[str, Any], expect: dict[str, Any], setup: dict[str, Any]
+) -> None:
+    """Simulate the normative preflight/diff/atomicity rules without an engine."""
+    manifest_path = resolve(input_data["pack"])
+    manifest = load_yaml(manifest_path)
+    resources = manifest.get("resources", []) or []
+    live = {
+        str(target): str(content).encode()
+        for target, content in (setup.get("files") or {}).items()
+    }
+    corrupt_digest = input_data.get("corrupt_digest") is True
+    runs: list[dict[str, Any]] = []
+
+    for _ in range(int(input_data.get("repeat", 1))):
+        planned: list[tuple[str, bytes, str]] = []
+        error: dict[str, str] | None = None
+        seen_sources: set[str] = set()
+        seen_targets: set[str] = set()
+        for index, resource in enumerate(resources):
+            source = resource.get("source")
+            target = resource.get("target")
+            digest = resource.get("digest")
+            if not all(isinstance(value, str) for value in (source, target, digest)):
+                error = {"code": "invalid_type_pack", "message": "incomplete resource"}
+                break
+            if source in seen_sources or target in seen_targets:
+                error = {"code": "invalid_type_pack", "message": "duplicate resource"}
+                break
+            seen_sources.add(source)
+            seen_targets.add(target)
+            source_path = (manifest_path.parent / source).resolve()
+            try:
+                source_path.relative_to(manifest_path.parent.resolve())
+            except ValueError:
+                error = {"code": "invalid_type_pack", "message": "unsafe source"}
+                break
+            if not source_path.is_file():
+                error = {"code": "invalid_type_pack", "message": "missing source"}
+                break
+            document = source_path.read_bytes()
+            actual_digest = "sha256:" + hashlib.sha256(document).hexdigest()
+            declared_digest = (
+                "sha256:" + ("0" * 64) if corrupt_digest and index == 0 else digest
+            )
+            if actual_digest != declared_digest:
+                error = {"code": "invalid_type_pack", "message": "digest mismatch"}
+                break
+            action = (
+                "create"
+                if target not in live
+                else "unchanged"
+                if live[target] == document
+                else "replace"
+            )
+            planned.append((target, document, action))
+
+        if error is None and len(planned) != len(resources):
+            error = {"code": "invalid_type_pack", "message": "incomplete pack"}
+        if error is None and any(action == "replace" for _, _, action in planned):
+            error = {"code": "type_pack_conflict", "message": "target conflict"}
+
+        if error is not None:
+            runs.append({"valid": False, "actions": [], "error": error})
+            break
+
+        for target, document, _ in planned:
+            live[target] = document
+        runs.append(
+            {
+                "valid": True,
+                "actions": [action for _, _, action in planned],
+            }
+        )
+
+    implementation_count = 0
+    for target, document in live.items():
+        if not target.startswith("_types/") or not target.endswith(".md"):
+            continue
+        try:
+            frontmatter = parse_markdown_frontmatter_text(document.decode(), target)
+        except (UnicodeDecodeError, ValueError, yaml.YAMLError):
+            continue
+        implementation_count += sum(
+            1
+            for implementation in frontmatter.get("implements", []) or []
+            if implementation.get("contract") == "tasknotes.task"
+            and implementation.get("version") == "0.2.0"
+        )
+
+    last = runs[-1]
+    actual = {
+        "valid": last["valid"],
+        "runs": runs,
+        "implementations": implementation_count,
+        "targets_exist": [
+            resource.get("target") in live for resource in resources
+        ],
+    }
+    if "error" in last:
+        actual["error"] = last["error"]
+    assert_subset(actual, expect)
+
+
 def run_data_contract_implementation_test(
     input_data: dict[str, Any], expect: dict[str, Any]
 ) -> None:
@@ -594,9 +703,23 @@ def run_data_contract_implementation_test(
 def data_contract_digest(contract: dict[str, Any]) -> str:
     payload = {
         key: contract[key]
-        for key in ("kind", "id", "version", "schema", "binding_schema")
+        for key in ("kind", "id", "version")
         if key in contract
     }
+    if "schema" in contract:
+        schema = contract["schema"]
+        payload["schema"] = (
+            schema["value"]
+            if isinstance(schema, dict) and "value" in schema
+            else schema
+        )
+    if "binding_schema" in contract:
+        binding_schema = contract["binding_schema"]
+        payload["binding_schema"] = (
+            binding_schema["value"]
+            if isinstance(binding_schema, dict) and "value" in binding_schema
+            else binding_schema
+        )
     canonical = json.dumps(
         payload,
         ensure_ascii=False,

--- a/scripts/migrate_v02_collection.py
+++ b/scripts/migrate_v02_collection.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 """Stage or apply a complete mdbase v0.2 collection metadata migration.
 
-The migrator rewrites only ``mdbase.yaml`` and Markdown files in the configured
-types folder. Record files are never modified. It flattens v0.2 inheritance,
-maps field definitions to JSON Schema, and moves collection behavior into the
-v0.3 ``collection`` and ``lifecycle`` sections.
+The migrator rewrites only ``mdbase.yaml`` and control files in the configured
+types and contracts folders. Record files are never modified. It flattens v0.2
+inheritance, maps field definitions to JSON Schema, and moves collection
+behavior into the v0.3 ``collection`` and ``lifecycle`` sections.
 
-TaskNotes-generated types receive the ``tasknotes.task`` contract wrapper used
-by current TaskNotes releases. Source features without a portable v0.3 mapping
-are retained under ``x-legacy-v0.2`` and listed in the report.
+TaskNotes-generated types receive a first-class ``tasknotes.task``
+implementation and the exact local contract artifact. Source features without
+a portable v0.3 mapping are retained under ``x-legacy-v0.2`` and listed in the
+report.
 """
 
 from __future__ import annotations
@@ -35,9 +36,15 @@ from jsonschema import Draft202012Validator
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CONFIG_SCHEMA = REPO_ROOT / "schemas/v0.3/config.schema.json"
 TYPE_FILE_SCHEMA = REPO_ROOT / "schemas/v0.3/type-file.schema.json"
+DATA_CONTRACT_SCHEMA = REPO_ROOT / "schemas/v0.3/data-contract.schema.json"
+TASKNOTES_CONTRACT_SOURCE = (
+    REPO_ROOT
+    / "examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md"
+)
 FRONTMATTER = re.compile(r"\A---(?:\r?\n)(.*?)(?:\r?\n)---(?=\r?\n|\Z)", re.S)
 CORE_CONFIG_SETTINGS = {
     "types_folder",
+    "contracts_folder",
     "record_extensions",
     "validation",
     "explicit_type_keys",
@@ -170,7 +177,33 @@ def analyze(collection: Path, output: Path, mdb_bin: Path | None) -> dict[str, A
                 "source_sha256": sha256(source.path.read_bytes()),
                 "target_sha256": sha256(rendered.encode()),
                 "flattened_inheritance": inheritance,
-                "tasknotes_contract": migrated.get("x-tasknotes", {}).get("contract"),
+                "tasknotes_contract": next(
+                    (
+                        implementation.get("contract")
+                        for implementation in migrated.get("implements", [])
+                        if implementation.get("contract") == "tasknotes.task"
+                    ),
+                    None,
+                ),
+            }
+        )
+
+    contract_summaries: list[dict[str, Any]] = []
+    if any(item["tasknotes_contract"] == "tasknotes.task" for item in type_summaries):
+        contracts_folder = str(proposed_config["settings"]["contracts_folder"])
+        contract_relative = Path(contracts_folder) / "tasknotes.task.md"
+        contract_frontmatter = load_markdown_frontmatter(TASKNOTES_CONTRACT_SOURCE)
+        validate_schema(DATA_CONTRACT_SCHEMA, contract_frontmatter, "data contract tasknotes.task")
+        contract_bytes = TASKNOTES_CONTRACT_SOURCE.read_bytes()
+        contract_target = proposed / contract_relative
+        contract_target.parent.mkdir(parents=True, exist_ok=True)
+        contract_target.write_bytes(contract_bytes)
+        contract_summaries.append(
+            {
+                "id": "tasknotes.task",
+                "version": "0.2.0",
+                "path": contract_relative.as_posix(),
+                "target_sha256": sha256(contract_bytes),
             }
         )
 
@@ -214,6 +247,7 @@ def analyze(collection: Path, output: Path, mdb_bin: Path | None) -> dict[str, A
             "target_sha256": sha256((proposed / "mdbase.yaml").read_bytes()),
         },
         "types": sorted(type_summaries, key=lambda item: item["name"].casefold()),
+        "contracts": contract_summaries,
         "unsupported": unsupported,
         "target_validation": target_validation,
         "record_validation": record_validation,
@@ -276,6 +310,7 @@ def migrate_config(source: dict[str, Any]) -> dict[str, Any]:
     if "extensions" in settings and "record_extensions" not in target_settings:
         target_settings["record_extensions"] = [str(value).lstrip(".") for value in settings["extensions"]]
     target_settings.setdefault("record_extensions", ["md"])
+    target_settings.setdefault("contracts_folder", "_contracts")
     target_settings.setdefault("validation", "warn")
     # Preserve an explicitly empty list: this collection uses CSL's `type`
     # field as data and therefore cannot use the default explicit type keys.
@@ -448,28 +483,29 @@ def migrate_type(
             }
         status_field = tasknotes_roles.get("status")
         priority_field = tasknotes_roles.get("priority")
-        target["x-tasknotes"] = {
-            "contract": "tasknotes.task",
-            "version": 1,
-            "field_roles": tasknotes_roles,
-            "status": {
-                "completed_values": completed_values,
-                **(
-                    {"default": read_defaults[status_field]}
-                    if status_field in read_defaults
-                    else {}
-                ),
-            },
-            "priority": (
-                {"default": read_defaults[priority_field]}
-                if priority_field in read_defaults
-                else {}
-            ),
-            "archive": {
-                "tags_field": tasknotes_roles.get("tags", "tags"),
-                "archived_tag": "archived",
-            },
-        }
+        target["implements"] = [
+            {
+                "contract": "tasknotes.task",
+                "version": "0.2.0",
+                "fields": tasknotes_roles,
+                "binding": {
+                    "status": {
+                        "completed_values": completed_values,
+                        **(
+                            {"default": read_defaults[status_field]}
+                            if status_field in read_defaults
+                            else {}
+                        ),
+                    },
+                    "priority": (
+                        {"default": read_defaults[priority_field]}
+                        if priority_field in read_defaults
+                        else {}
+                    ),
+                    "archive": {"archived_tag": "archived"},
+                },
+            }
+        ]
 
     if collection:
         target["collection"] = collection
@@ -732,13 +768,16 @@ def migrated_body(source: SourceType, target: dict[str, Any]) -> str:
             "This materialized meta type mirrors the canonical mdbase v0.3 type-file schema.\n"
             "The implementation's built-in schema remains authoritative during collection bootstrap.\n"
         )
-    if target.get("x-tasknotes", {}).get("contract") == "tasknotes.task":
+    if any(
+        implementation.get("contract") == "tasknotes.task"
+        for implementation in target.get("implements", [])
+    ):
         return (
             "\n\n# Task\n\n"
             "This type definition is generated from TaskNotes settings for mdbase v0.3.\n"
             "Its JSON Schema describes persisted task frontmatter; collection and lifecycle\n"
-            "metadata describe generic mdbase behavior; `x-tasknotes` records the optional\n"
-            "TaskNotes task contract.\n\n"
+            "metadata describe generic mdbase behavior; `implements` maps the exact\n"
+            "TaskNotes task data contract.\n\n"
             "This file is automatically generated and should not be edited manually.\n"
         )
     return source.body
@@ -763,6 +802,15 @@ def validate_staged_collection(
         if staged_types.exists():
             shutil.rmtree(staged_types)
         shutil.copytree(proposed / target_types, staged_types)
+        target_contracts = load_yaml(proposed / "mdbase.yaml")["settings"].get(
+            "contracts_folder", "_contracts"
+        )
+        proposed_contracts = proposed / target_contracts
+        if proposed_contracts.exists():
+            staged_contracts = stage / target_contracts
+            if staged_contracts.exists():
+                shutil.rmtree(staged_contracts)
+            shutil.copytree(proposed_contracts, staged_contracts)
         target = run_mdb_validate(mdb, stage)
 
     baseline_keys = diagnostic_keys(baseline)
@@ -877,24 +925,28 @@ def apply_migration(
     if backup.exists():
         raise SystemExit(f"backup already exists: {backup}")
     backup.mkdir(parents=True)
-    paths = [Path("mdbase.yaml"), *(Path(item["path"]) for item in report["types"])]
+    paths = [
+        Path("mdbase.yaml"),
+        *(Path(item["path"]) for item in report["types"]),
+        *(Path(item["path"]) for item in report.get("contracts", [])),
+    ]
     manifest = {"collection": str(collection), "files": []}
     for relative in paths:
         source = collection / relative
-        backup_file = backup / relative
-        backup_file.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source, backup_file)
-        manifest["files"].append(
-            {
-                "path": relative.as_posix(),
-                "sha256": sha256(source.read_bytes()),
-            }
-        )
+        existed = source.exists()
+        item = {"path": relative.as_posix(), "existed": existed}
+        if existed:
+            backup_file = backup / relative
+            backup_file.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, backup_file)
+            item["sha256"] = sha256(source.read_bytes())
+        manifest["files"].append(item)
     (backup / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
 
     for relative in paths:
         target = collection / relative
         staged = proposed / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
         temporary = target.with_name(f".{target.name}.mdbase-v03.tmp")
         shutil.copy2(staged, temporary)
         os.replace(temporary, target)
@@ -914,6 +966,16 @@ def validate_schema(schema_path: Path, value: Any, label: str) -> None:
 
 def load_yaml(path: Path) -> Any:
     return normalize_yaml(yaml.safe_load(path.read_text()))
+
+
+def load_markdown_frontmatter(path: Path) -> dict[str, Any]:
+    match = FRONTMATTER.match(path.read_text())
+    if not match:
+        raise SystemExit(f"control file lacks frontmatter: {path}")
+    value = normalize_yaml(yaml.safe_load(match.group(1)) or {})
+    if not isinstance(value, dict):
+        raise SystemExit(f"control file frontmatter is not a mapping: {path}")
+    return value
 
 
 def normalize_yaml(value: Any) -> Any:

--- a/scripts/prototype_tasknotes_v03_migration.py
+++ b/scripts/prototype_tasknotes_v03_migration.py
@@ -8,7 +8,7 @@ be transformed into the v0.3 split:
 - JSON Schema frontmatter shape
 - `collection` defaults, links, display, and path policy
 - `lifecycle` managed fields
-- `x-tasknotes` extension metadata
+- a first-class `tasknotes.task` implementation
 - machine-readable migration report
 """
 
@@ -196,17 +196,18 @@ def migrate_tasknotes_type(old: dict[str, Any]) -> dict[str, Any]:
             "path": migrate_path_policy(old.get("path_pattern")),
         },
         "lifecycle": lifecycle,
-        "x-tasknotes": {
-            "contract": "tasknotes.task",
-            "version": 1,
-            "field_roles": field_roles,
-            "status": status_metadata,
-            "priority": priority_metadata,
-            "archive": {
-                "tags_field": field_roles.get("tags", "tags"),
-                "archived_tag": "archived",
-            },
-        },
+        "implements": [
+            {
+                "contract": "tasknotes.task",
+                "version": "0.2.0",
+                "fields": field_roles,
+                "binding": {
+                    "status": status_metadata,
+                    "priority": priority_metadata,
+                    "archive": {"archived_tag": "archived"},
+                },
+            }
+        ],
     }
 
     return prune_empty(task_type)
@@ -315,10 +316,10 @@ def build_report(old: dict[str, Any], migrated: dict[str, Any]) -> dict[str, Any
             "tasknotes_annotations_moved": True,
         },
         "mappings": [
-            {"from": "fields.title", "to": ["schema.value.properties.title", "x-tasknotes.field_roles.title"]},
+            {"from": "fields.title", "to": ["schema.value.properties.title", "implements.0.fields.title"]},
             {"from": "fields.status.values", "to": "schema.value.properties.status.enum"},
-            {"from": "fields.status.default", "to": ["schema.value.properties.status.default", "collection.read_defaults.status", "x-tasknotes.status.default"]},
-            {"from": "fields.status.tn_completed_values", "to": "x-tasknotes.status.completed_values"},
+            {"from": "fields.status.default", "to": ["schema.value.properties.status.default", "collection.read_defaults.status", "implements.0.binding.status.default"]},
+            {"from": "fields.status.tn_completed_values", "to": "implements.0.binding.status.completed_values"},
             {"from": "fields.dateCreated.generated", "to": "lifecycle.on_create.set.dateCreated"},
             {"from": "fields.dateModified.generated", "to": "lifecycle.on_update.set.dateModified"},
             {"from": "fields.projects.items.type", "to": ["schema.value.properties.projects.items.type", "collection.links.projects[]"]},

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -78,6 +78,7 @@ const SPEC_FILES = [
   { file: '03-records-and-frontmatter.md', num: '03', title: 'Records & Frontmatter', id: 'section-03' },
   { file: '04-configuration.md',          num: '04', title: 'Configuration',        id: 'section-04' },
   { file: '05-type-files.md',             num: '05', title: 'Type Files',           id: 'section-05' },
+  { file: '05-data-contracts.md',         num: '05A', title: 'Data Contracts',      id: 'section-05a' },
   { file: '06-json-schema-profile.md',    num: '06', title: 'JSON Schema Profile',  id: 'section-06' },
   { file: '07-collection-semantics.md',   num: '07', title: 'Collection Semantics', id: 'section-07' },
   { file: '08-links.md',                  num: '08', title: 'Links',                id: 'section-08' },

--- a/tests/v0.3/README.md
+++ b/tests/v0.3/README.md
@@ -4,17 +4,18 @@ This directory is the parallel v0.3 conformance suite. It does not replace the
 existing `tests/level-*` v0.2.x suite.
 
 v0.3 conformance claims use the atomic profiles defined by the specification.
-The tests below are grouped into nine fixture sets for the rollout plan:
+The tests below are grouped into ten fixture sets for the rollout plan:
 
 1. `schema_artifacts`
 2. `migration`
 3. `core_collection`
 4. `data_contracts`
 5. `lifecycle`
-6. `cel`
-7. `views`
-8. `runtime_contracts`
-9. `workflow_execution`
+6. `type_packs`
+7. `cel`
+8. `views`
+9. `runtime_contracts`
+10. `workflow_execution`
 
 The suite covers JSON Schema artifacts, type wrappers, first-class data
 contracts and projections, collection semantics, CEL host bindings, saved

--- a/tests/v0.3/README.md
+++ b/tests/v0.3/README.md
@@ -4,19 +4,22 @@ This directory is the parallel v0.3 conformance suite. It does not replace the
 existing `tests/level-*` v0.2.x suite.
 
 v0.3 conformance claims use the atomic profiles defined by the specification.
-The tests below are grouped into seven fixture sets for the rollout plan:
+The tests below are grouped into nine fixture sets for the rollout plan:
 
 1. `schema_artifacts`
 2. `migration`
 3. `core_collection`
-4. `lifecycle`
-5. `cel`
-6. `views`
-7. `runtime_contracts`
+4. `data_contracts`
+5. `lifecycle`
+6. `cel`
+7. `views`
+8. `runtime_contracts`
+9. `workflow_execution`
 
-The suite covers JSON Schema artifacts, type wrappers, collection semantics,
-CEL host bindings, saved views, lifecycle operations, runtime contract
-registries, workflow preflight, and execution cases for available adapters.
+The suite covers JSON Schema artifacts, type wrappers, first-class data
+contracts and projections, collection semantics, CEL host bindings, saved
+views, lifecycle operations, runtime contract registries, workflow preflight,
+and execution cases for available adapters.
 Compatible v0.2 fixtures remain useful for frontmatter parsing, missing/null
 semantics, links, operation safety, and watch ordering. Tests tied to the
 earlier custom field grammar are migrated into the v0.3 fixture sets.
@@ -79,6 +82,8 @@ Future v0.3 adapters should support these operations:
 - `load_config`
 - `load_types`
 - `get_types`
+- `get_data_contracts`
+- `get_contract_view`
 - `read`
 - `validate`
 - `query`
@@ -94,6 +99,7 @@ Future v0.3 adapters should support these operations:
 - `runtime_validate_action_input`
 - `runtime_validate_action_output`
 - `migrate_type`
+- `install_type_pack`
 
 The repository also includes `scripts/check_v03_tests.py`, which validates the
 suite structure and executes local artifact checks that do not require a full

--- a/tests/v0.3/data-contracts/data-contracts.yaml
+++ b/tests/v0.3/data-contracts/data-contracts.yaml
@@ -84,7 +84,7 @@ groups:
         input:
           contract: "examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md"
         expect:
-          digest: "sha256:7174b83651f68fd061b37f7fdf0c90f3a5e54ec87ed7c5e709fd7e3b9415c5c7"
+          digest: "sha256:7111c47ba7b1abed8c9823500c30ce0b80d3b3950a982d0acbc29523b5cb4d1c"
         covers:
           - core_read.data_contract_digest
 
@@ -95,7 +95,7 @@ groups:
           contract: "examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md"
           type: "examples/v0.3/tasknotes-migration/v0.3/_types/task.md"
         expect:
-          digest: "sha256:69e4f95ca2785c59756ab80bd4cc2f1f1498449221ed3d18de37f43f6972fcc8"
+          digest: "sha256:2d3a40ba07e03e20a6bd1eae2f44c267a5bb14c3e693f09629f28b7a69277601"
         covers:
           - core_read.data_contract_implementation_digest
 

--- a/tests/v0.3/data-contracts/data-contracts.yaml
+++ b/tests/v0.3/data-contracts/data-contracts.yaml
@@ -1,0 +1,206 @@
+name: "v0.3 data contract conformance"
+spec_version: "0.3.0"
+fixture_set: data_contracts
+category: data_contracts
+spec_ref: "v0.3/02, v0.3/04, v0.3/05, v0.3/05A, v0.3/06, v0.3/16"
+
+groups:
+  - name: "contract artifacts and implementations"
+    tests:
+      - id: data-contract-schema
+        name: "data contract frontmatter and embedded schemas validate"
+        operation: data_contract_implementation_validate
+        input:
+          contract: "examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md"
+          type: "examples/v0.3/tasknotes-migration/v0.3/_types/task.md"
+        expect:
+          valid: true
+        covers:
+          - core_read.data_contract_discovery
+          - core_read.data_contract_schema_validation
+          - core_read.data_contract_implementation_validation
+
+      - id: data-contract-projection
+        name: "a valid record projects through the declared field map"
+        operation: data_contract_implementation_validate
+        input:
+          contract: "examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md"
+          type: "examples/v0.3/tasknotes-migration/v0.3/_types/task.md"
+          record: "tests/v0.3/fixtures/data-contracts/valid-task.yml"
+        expect:
+          valid: true
+        covers:
+          - core_read.data_contract_projection
+
+      - name: "binding schema rejects incomplete semantic configuration"
+        operation: data_contract_implementation_validate
+        input:
+          contract: "examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md"
+          type: "tests/v0.3/fixtures/data-contracts/invalid-binding-type.md"
+        expect:
+          valid: false
+          error_contains: "binding"
+
+      - name: "all unconditionally required contract fields are mapped"
+        operation: data_contract_implementation_validate
+        input:
+          contract: "examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md"
+          type: "tests/v0.3/fixtures/data-contracts/missing-required-map-type.md"
+        expect:
+          valid: false
+          error_contains: "required contract field"
+
+      - name: "mapped record fields must exist in the type schema"
+        operation: data_contract_implementation_validate
+        input:
+          contract: "examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md"
+          type: "tests/v0.3/fixtures/data-contracts/unknown-record-field-type.md"
+        expect:
+          valid: false
+          error_contains: "record field is not declared"
+
+      - name: "contract view validation rejects an invalid projected record"
+        operation: data_contract_implementation_validate
+        input:
+          contract: "examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md"
+          type: "examples/v0.3/tasknotes-migration/v0.3/_types/task.md"
+          record: "tests/v0.3/fixtures/data-contracts/invalid-task.yml"
+        expect:
+          valid: false
+          error_contains: "record"
+
+      - name: "legacy x extensions do not implement data contracts"
+        operation: data_contract_implementation_validate
+        input:
+          contract: "examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md"
+          type: "tests/v0.3/fixtures/data-contracts/legacy-extension-type.md"
+        expect:
+          valid: false
+          error_contains: "exactly one implementation"
+
+      - id: data-contract-digest
+        name: "contract digest is deterministic over portable semantics"
+        operation: data_contract_digest
+        input:
+          contract: "examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md"
+        expect:
+          digest: "sha256:7174b83651f68fd061b37f7fdf0c90f3a5e54ec87ed7c5e709fd7e3b9415c5c7"
+        covers:
+          - core_read.data_contract_digest
+
+      - id: data-contract-implementation-digest
+        name: "implementation digest pins contract, type semantics, and binding"
+        operation: data_contract_implementation_digest
+        input:
+          contract: "examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md"
+          type: "examples/v0.3/tasknotes-migration/v0.3/_types/task.md"
+        expect:
+          digest: "sha256:69e4f95ca2785c59756ab80bd4cc2f1f1498449221ed3d18de37f43f6972fcc8"
+        covers:
+          - core_read.data_contract_implementation_digest
+
+      - id: data-contract-conflict
+        name: "different content for one exact contract identity conflicts"
+        operation: data_contract_registry_validate
+        input:
+          paths:
+            - "examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md"
+            - "tests/v0.3/fixtures/data-contracts/conflicting-tasknotes.task.md"
+        expect:
+          valid: false
+          error_contains: "data contract conflict"
+        covers:
+          - core_read.data_contract_conflict
+
+  - name: "multiple local implementations"
+    setup:
+      config: |
+        spec_version: "0.3.0"
+        settings:
+          types_folder: _types
+          contracts_folder: _contracts
+          explicit_type_keys: [type]
+      contracts:
+        example.note.md: |
+          ---
+          kind: mdbase.contract
+          id: example.note
+          version: 1.0.0
+          schema:
+            dialect: json-schema-2020-12
+            value:
+              type: object
+              required: [title]
+              properties:
+                title: { type: string }
+          ---
+      types:
+        personal-note.md: |
+          ---
+          kind: mdbase.type
+          name: personal_note
+          version: 1
+          schema:
+            dialect: json-schema-2020-12
+            value:
+              type: object
+              required: [type, title]
+              properties:
+                type: { const: personal_note }
+                title: { type: string }
+          implements:
+            - contract: example.note
+              version: 1.0.0
+              fields:
+                title: title
+          ---
+        work-note.md: |
+          ---
+          kind: mdbase.type
+          name: work_note
+          version: 1
+          schema:
+            dialect: json-schema-2020-12
+            value:
+              type: object
+              required: [type, summary]
+              properties:
+                type: { const: work_note }
+                summary: { type: string }
+          implements:
+            - contract: example.note
+              version: 1.0.0
+              fields:
+                title: summary
+          ---
+      files:
+        personal.md: |
+          ---
+          type: personal_note
+          title: Personal note
+          ---
+        work.md: |
+          ---
+          type: work_note
+          summary: Work note
+          ---
+    tests:
+      - name: "lookup returns every implementing type in canonical order"
+        operation: get_data_contracts
+        input:
+          contract: example.note
+          version: 1.0.0
+        expect:
+          implementations:
+            - type: personal_note
+            - type: work_note
+
+      - name: "each implementing record exposes the normalized contract view"
+        operation: get_contract_view
+        input:
+          path: work.md
+          contract: example.note
+          version: 1.0.0
+        expect:
+          view:
+            title: Work note

--- a/tests/v0.3/fixtures/data-contracts/conflicting-tasknotes.task.md
+++ b/tests/v0.3/fixtures/data-contracts/conflicting-tasknotes.task.md
@@ -1,0 +1,15 @@
+---
+kind: mdbase.contract
+id: tasknotes.task
+version: 0.2.0
+name: Conflicting TaskNotes task
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+    required: [different]
+    properties:
+      different: { type: boolean }
+---
+
+# Deliberately conflicting contract fixture

--- a/tests/v0.3/fixtures/data-contracts/invalid-binding-type.md
+++ b/tests/v0.3/fixtures/data-contracts/invalid-binding-type.md
@@ -1,0 +1,28 @@
+---
+kind: mdbase.type
+name: invalid_binding_task
+version: 1
+match:
+  path_glob: "invalid-binding/**/*.md"
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+    required: [title, status, dateCreated]
+    properties:
+      title: { type: string }
+      status: { type: string }
+      dateCreated: { type: string, format: date-time }
+implements:
+  - contract: tasknotes.task
+    version: 0.2.0
+    fields:
+      title: title
+      status: status
+      dateCreated: dateCreated
+    binding:
+      status:
+        completed_values: [done]
+---
+
+# Invalid binding fixture

--- a/tests/v0.3/fixtures/data-contracts/invalid-task.yml
+++ b/tests/v0.3/fixtures/data-contracts/invalid-task.yml
@@ -1,0 +1,2 @@
+status: open
+dateCreated: "2026-07-28T09:00:00+10:00"

--- a/tests/v0.3/fixtures/data-contracts/legacy-extension-type.md
+++ b/tests/v0.3/fixtures/data-contracts/legacy-extension-type.md
@@ -1,0 +1,18 @@
+---
+kind: mdbase.type
+name: legacy_task
+version: 1
+match:
+  path_glob: "legacy/**/*.md"
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+    properties:
+      title: { type: string }
+x-tasknotes:
+  contract: tasknotes.task
+  version: 1
+---
+
+# Legacy extension fixture

--- a/tests/v0.3/fixtures/data-contracts/missing-required-map-type.md
+++ b/tests/v0.3/fixtures/data-contracts/missing-required-map-type.md
@@ -1,0 +1,28 @@
+---
+kind: mdbase.type
+name: incomplete_task
+version: 1
+match:
+  path_glob: "incomplete/**/*.md"
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+    required: [title, status, dateCreated]
+    properties:
+      title: { type: string }
+      status: { type: string }
+      dateCreated: { type: string, format: date-time }
+implements:
+  - contract: tasknotes.task
+    version: 0.2.0
+    fields:
+      status: status
+      dateCreated: dateCreated
+    binding:
+      status:
+        completed_values: [done]
+        default: open
+---
+
+# Missing required field map fixture

--- a/tests/v0.3/fixtures/data-contracts/unknown-record-field-type.md
+++ b/tests/v0.3/fixtures/data-contracts/unknown-record-field-type.md
@@ -1,0 +1,29 @@
+---
+kind: mdbase.type
+name: unknown_field_task
+version: 1
+match:
+  path_glob: "unknown-field/**/*.md"
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+    required: [title, status, dateCreated]
+    properties:
+      title: { type: string }
+      status: { type: string }
+      dateCreated: { type: string, format: date-time }
+implements:
+  - contract: tasknotes.task
+    version: 0.2.0
+    fields:
+      title: missing_title
+      status: status
+      dateCreated: dateCreated
+    binding:
+      status:
+        completed_values: [done]
+        default: open
+---
+
+# Unknown record field fixture

--- a/tests/v0.3/fixtures/data-contracts/valid-task.yml
+++ b/tests/v0.3/fixtures/data-contracts/valid-task.yml
@@ -1,0 +1,3 @@
+title: Contract fixture
+status: open
+dateCreated: "2026-07-28T09:00:00+10:00"

--- a/tests/v0.3/manifest.yaml
+++ b/tests/v0.3/manifest.yaml
@@ -82,7 +82,11 @@ claim_profiles:
   - id: core_write
     status: draft
     requires: [collection_semantics]
-    requirements: []
+    requirements:
+      - transactional_type_pack_preflight
+      - exact_type_pack_diff
+      - idempotent_type_pack_install
+      - type_pack_atomicity
   - id: lifecycle
     status: draft
     requires: [core_write, cel]
@@ -147,6 +151,11 @@ fixture_sets:
     coverage_targets: [core_read]
     files:
       - data-contracts/data-contracts.yaml
+  - id: type_packs
+    description: Complete type packs validate, report exact diffs, install atomically, and reinstall idempotently.
+    coverage_targets: [core_write]
+    files:
+      - type-packs/type-packs.yaml
   - id: lifecycle
     description: on_create/on_update managed field behavior replacing generated fields.
     coverage_targets: [lifecycle]

--- a/tests/v0.3/manifest.yaml
+++ b/tests/v0.3/manifest.yaml
@@ -26,6 +26,13 @@ claim_profiles:
       - json_schema_annotations
       - json_schema_formats
       - local_schema_ref
+      - data_contract_discovery
+      - data_contract_schema_validation
+      - data_contract_implementation_validation
+      - data_contract_projection
+      - data_contract_digest
+      - data_contract_implementation_digest
+      - data_contract_conflict
       - explicit_and_basic_matching
       - raw_schema_validation
       - machine_readable_diagnostics
@@ -135,6 +142,11 @@ fixture_sets:
     coverage_targets: [core_read, collection_semantics, links, core_write]
     files:
       - core/core-collection.yaml
+  - id: data_contracts
+    description: Data contracts, type implementations, projections, stable digests, and conflicts.
+    coverage_targets: [core_read]
+    files:
+      - data-contracts/data-contracts.yaml
   - id: lifecycle
     description: on_create/on_update managed field behavior replacing generated fields.
     coverage_targets: [lifecycle]

--- a/tests/v0.3/migration/tasknotes-type-migration.yaml
+++ b/tests/v0.3/migration/tasknotes-type-migration.yaml
@@ -30,7 +30,7 @@ groups:
           report_contains:
             mappings:
               - from: "fields.title"
-                to: ["schema.value.properties.title", "x-tasknotes.field_roles.title"]
+                to: ["schema.value.properties.title", "implements.0.fields.title"]
               - from: "fields.status.values"
                 to: "schema.value.properties.status.enum"
 
@@ -99,14 +99,14 @@ groups:
         expect:
           valid: true
 
-      - name: "TaskNotes semantic metadata stays outside JSON Schema properties"
+      - name: "TaskNotes contract implementation stays outside JSON Schema properties"
         operation: inspect_yaml
         input:
           path: "examples/v0.3/tasknotes-migration/v0.3/_types/task.md"
         expect:
           has:
-            - "/x-tasknotes/field_roles/status"
-            - "/x-tasknotes/archive/archived_tag"
+            - "/implements/0/fields/status"
+            - "/implements/0/binding/archive/archived_tag"
           not_has:
             - "/schema/value/properties/status/tn_role"
             - "/schema/value/properties/status/tn_completed_values"

--- a/tests/v0.3/runtime-contracts/runtime-contracts.yaml
+++ b/tests/v0.3/runtime-contracts/runtime-contracts.yaml
@@ -565,5 +565,5 @@ groups:
         expect:
           valid: false
           diagnostics:
-            - code: contract_conflict
+            - code: runtime_contract_conflict
               id: duplicate.event

--- a/tests/v0.3/schema/schema-artifacts.yaml
+++ b/tests/v0.3/schema/schema-artifacts.yaml
@@ -78,6 +78,42 @@ groups:
         expect:
           valid: true
 
+      - name: "data-contract schema validates the TaskNotes contract"
+        operation: markdown_frontmatter_schema_validate
+        input:
+          schema: "schemas/v0.3/data-contract.schema.json"
+          paths:
+            - "examples/v0.3/tasknotes-migration/v0.3/_contracts/*.md"
+        expect:
+          valid: true
+
+      - name: "TaskNotes contract record and binding schemas are valid JSON Schema"
+        operation: embedded_json_schema_validate
+        input:
+          paths:
+            - "examples/v0.3/tasknotes-migration/v0.3/_contracts/tasknotes.task.md"
+          pointers:
+            - "/schema/value"
+            - "/binding_schema/value"
+        expect:
+          valid: true
+
+      - name: "type-pack schema validates the TaskNotes pack"
+        operation: yaml_document_schema_validate
+        input:
+          schema: "schemas/v0.3/type-pack.schema.json"
+          paths:
+            - "examples/v0.3/tasknotes-migration/v0.3/mdbase-pack.yaml"
+        expect:
+          valid: true
+
+      - name: "TaskNotes pack resources match their declared digests"
+        operation: type_pack_resources_validate
+        input:
+          path: "examples/v0.3/tasknotes-migration/v0.3/mdbase-pack.yaml"
+        expect:
+          valid: true
+
       - name: "type-file schema validates the canonical view type"
         operation: markdown_frontmatter_schema_validate
         input:

--- a/tests/v0.3/type-packs/type-packs.yaml
+++ b/tests/v0.3/type-packs/type-packs.yaml
@@ -1,0 +1,76 @@
+name: "v0.3 transactional type-pack conformance"
+spec_version: "0.3.0"
+fixture_set: type_packs
+category: type_packs
+spec_ref: "v0.3/05A, v0.3/16"
+
+groups:
+  - name: "complete installation and idempotency"
+    setup:
+      config: |
+        spec_version: "0.3.0"
+        settings:
+          validation: error
+    tests:
+      - id: type-pack-install-idempotent
+        name: "a complete pack installs as one exact diff and identical reinstall is unchanged"
+        operation: install_type_pack
+        input:
+          pack: "examples/v0.3/tasknotes-migration/v0.3/mdbase-pack.yaml"
+          repeat: 2
+        expect:
+          valid: true
+          runs:
+            - valid: true
+              actions: [create, create]
+            - valid: true
+              actions: [unchanged, unchanged]
+          implementations: 1
+        covers:
+          - core_write.transactional_type_pack_preflight
+          - core_write.exact_type_pack_diff
+          - core_write.idempotent_type_pack_install
+
+  - name: "preflight failure is atomic"
+    setup:
+      config: |
+        spec_version: "0.3.0"
+        settings:
+          validation: error
+    tests:
+      - id: type-pack-digest-failure-atomic
+        name: "a digest mismatch writes no live target"
+        operation: install_type_pack
+        input:
+          pack: "examples/v0.3/tasknotes-migration/v0.3/mdbase-pack.yaml"
+          corrupt_digest: true
+        expect:
+          valid: false
+          error:
+            code: invalid_type_pack
+          targets_exist: [false, false]
+        covers:
+          - core_write.type_pack_atomicity
+
+  - name: "target conflicts are atomic"
+    setup:
+      config: |
+        spec_version: "0.3.0"
+        settings:
+          validation: error
+      files:
+        _contracts/tasknotes.task.md: |
+          Existing unrelated bytes.
+    tests:
+      - id: type-pack-target-conflict-atomic
+        name: "a differing target rejects the whole pack without creating later resources"
+        operation: install_type_pack
+        input:
+          pack: "examples/v0.3/tasknotes-migration/v0.3/mdbase-pack.yaml"
+        expect:
+          valid: false
+          error:
+            code: type_pack_conflict
+          targets_exist: [true, false]
+        covers:
+          - core_write.type_pack_atomicity

--- a/v0.3/17-promotion-plan.md
+++ b/v0.3/17-promotion-plan.md
@@ -109,8 +109,8 @@ not automatic silent conversion. Tools should:
 - offer dry-run migration reports before writes;
 - rewrite generated type files only when generated-file detection or explicit
   user approval is present;
-- preserve unknown domain metadata as `x-*`; named app sections should wait for
-  a future extension registry.
+- preserve unknown private domain metadata as `x-*`; portable interfaces use
+  first-class data contracts and type-local `implements` entries.
 
 ## Site Promotion Notes
 


### PR DESCRIPTION
Summary

- define mdbase.contract as a JSON Schema-backed resource
- put exact contract bindings in type implements entries
- specify union semantics, explicit create-provider selection, pinned grants, normalized views, and transactional type packs
- add executable schema and conformance coverage

Validation

- schema artifact validation
- 54 executable conformance checks
- 93 adapter-target checks
- canonical digest verification