### PR TITLE
Preserve exact type-pack bytes across platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/05-data-contracts.md
+++ b/05-data-contracts.md
@@ -288,6 +288,11 @@ resources:
 
 Resource digests are SHA-256 over the exact resource bytes. Source and target
 paths are relative, forward-slash paths without traversal.
+A directory, archive, repository, or package that distributes a pack MUST
+preserve those bytes exactly, including line endings. Rewriting a text resource
+from LF to CRLF therefore creates a different resource and MUST fail digest
+verification. This repository fixes text checkouts to LF so its example pack
+has identical bytes on every supported platform.
 
 Type packs are installation units, not record types and not permission grants.
 A pack may include several contracts, several implementing or auxiliary types,


### PR DESCRIPTION
Summary

- force repository text resources to use LF in every checkout
- clarify that pack distributors must preserve exact resource bytes, including line endings
- keep digest-pinned example packs reproducible on Windows, macOS, and Linux

Validation

- v0.3 suite checker passes: 54 executable and 93 adapter-target checks
- Windows failures in both reference implementations identified the line-ending conversion path