### PR TITLE
Add standard JSON Pointer field references

### DIFF
--- a/05-data-contracts.md
+++ b/05-data-contracts.md
@@ -121,6 +121,7 @@ implements:
       title: title
       status: workflow_state
       due: due_date
+      "/@type": "/card/@type"
     binding:
       completed_values: [done, cancelled]
 ```
@@ -131,18 +132,22 @@ Each implementation contains:
 | --- | --- |
 | `contract` | exact contract ID |
 | `version` | exact contract semantic version |
-| `fields` | contract field path to record field path mapping |
+| `fields` | contract field reference to record field reference mapping |
 | `binding` | optional configuration validated by the contract's `binding_schema` |
 
-Both sides of `fields` use the field-path syntax from Chapter 07. The left side
-addresses the normalized contract view. The right side addresses effective
-record frontmatter. Mapping is direct: core does not rename values, coerce
-values, run expressions, or apply hidden transforms.
+Both sides of `fields` use the field-reference syntax from Chapter 07. Existing
+field paths remain valid. RFC 6901 JSON Pointer is the exact form for keys that
+field paths cannot represent, so `/@type` addresses an `@type` property and
+`/a~1b` addresses an `a/b` property. The left side addresses the normalized
+contract view. The right side addresses effective record frontmatter. Mapping
+is direct: core does not rename values, coerce values, run expressions, or
+apply hidden transforms.
 
 A type MUST NOT contain two implementations of the same contract ID and
 version. Field mappings MUST address fields declared by the resolved contract
 schema and the resolved type schema. Every unconditional top-level field named
-by the contract schema's `required` array MUST be mapped.
+by the contract schema's `required` array MUST be mapped, either by the matching
+one-segment field path or by the matching one-token JSON Pointer.
 
 When a contract has a `binding_schema`, the implementation's `binding` value, or
 an empty object when omitted, MUST validate against it. When a contract has no
@@ -154,7 +159,7 @@ contract-discovery, conformance, or authorization meaning.
 ## Contract Views And Record Validation
 
 To construct a contract view, a tool starts with a record's effective
-frontmatter and copies every mapped value to its contract field path. Missing
+frontmatter and copies every mapped value to its contract field reference. Missing
 optional values remain missing. The resulting object is validated against the
 contract's `schema`.
 

--- a/07-collection-semantics.md
+++ b/07-collection-semantics.md
@@ -23,6 +23,35 @@ collection:
       validate_exists: true
 ```
 
+## Field References
+
+Every collection-semantic selector uses one field-reference syntax. A field
+reference is either:
+
+- the existing mdbase field-path form, such as `title`, `metadata.owner`, or
+  `blocks[]`
+- a non-root [RFC 6901 JSON Pointer](https://www.rfc-editor.org/rfc/rfc6901),
+  such as `/@type`, `/metadata/owner`, or `/schema/$id`
+
+Field paths remain supported for compatibility and for the `[]` array-item
+selector. JSON Pointer is the exact, standards-based form for every JSON object
+key, including keys that contain `.`, `/`, `~`, `@`, or `$`. Pointer tokens
+escape `~` as `~0` and `/` as `~1`; for example `/a~1b` selects the key `a/b`.
+The URI-fragment form beginning with `#` is not accepted.
+
+The empty JSON Pointer denotes the whole document in RFC 6901, but it is not a
+valid mdbase field reference. Collection semantics always address a field
+inside the frontmatter object.
+
+JSON Pointer resolves one exact value. Array tokens are zero-based indices.
+`[]` expansion belongs only to the field-path form. An operation that accepts a
+link collection applies its link rule to every item when the resolved value is
+an array.
+
+Lifecycle `set` creates missing intermediate objects. It MUST fail rather than
+replace a non-object intermediate value. Assignment through an array index is
+valid only when that array and index already exist.
+
 ## Matching Decision Process
 
 Matching uses the collection-relative record path, raw persisted frontmatter,
@@ -59,7 +88,7 @@ All members present in one `match` object combine with AND:
 ```yaml
 match:
   path_glob: "tasks/**/*.md"
-  fields_present: [title]
+  fields_present: [title, "/@type"]
   where:
     status:
       neq: done
@@ -163,10 +192,14 @@ collection:
     blocks[]:
       target_type: task
       validate_exists: false
+    "/relations":
+      target_type: task
+      validate_exists: true
 ```
 
 `blocks[]` applies the rule to every item in the `blocks` array. Chapter 08
-defines link parsing and resolution.
+defines link parsing and resolution. `/relations` applies the same item-wise
+rule when the exactly selected value is an array.
 
 ## Cross-File Uniqueness
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this specification and conformance suite are documented here.
 
+## 2026-07-28 (standard field references)
+
+### Added
+
+- Added non-root RFC 6901 JSON Pointer as the exact field-reference form for
+  collection semantics and data-contract mappings.
+- Added conformance coverage for JSON-LD `@type` and escaped `/` and `~`
+  property names.
+
+### Changed
+
+- Retained the existing mdbase field-path syntax as a compatible shorthand,
+  including its `[]` array-item selector.
+
 ## 2026-07-26 (exact record source)
 
 ### Added

--- a/packages/runtime-contracts/src/generated-schemas.ts
+++ b/packages/runtime-contracts/src/generated-schemas.ts
@@ -914,7 +914,26 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
       },
       "jsonPointer": {
         "type": "string",
+        "format": "json-pointer",
         "pattern": "^(/([^/~]|~0|~1)*)*$"
+      },
+      "fieldReference": {
+        "description": "A legacy mdbase field path or a non-root RFC 6901 JSON Pointer.",
+        "oneOf": [
+          {
+            "$ref": "#/$defs/fieldPath"
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/$defs/jsonPointer"
+              },
+              {
+                "minLength": 1
+              }
+            ]
+          }
+        ]
       },
       "jsonSchema": {
         "type": "object",
@@ -985,7 +1004,7 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
             "type": "array",
             "minItems": 1,
             "items": {
-              "$ref": "#/$defs/fieldPath"
+              "$ref": "#/$defs/fieldReference"
             },
             "uniqueItems": true
           },
@@ -1001,6 +1020,9 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
       "matchWhere": {
         "type": "object",
         "minProperties": 1,
+        "propertyNames": {
+          "$ref": "#/$defs/fieldReference"
+        },
         "additionalProperties": {
           "$ref": "#/$defs/matchPredicate"
         }
@@ -1089,16 +1111,16 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
         "type": "object",
         "properties": {
           "name_field": {
-            "$ref": "#/$defs/fieldPath"
+            "$ref": "#/$defs/fieldReference"
           },
           "description_field": {
-            "$ref": "#/$defs/fieldPath"
+            "$ref": "#/$defs/fieldReference"
           },
           "icon": {
             "type": "string"
           },
           "color_field": {
-            "$ref": "#/$defs/fieldPath"
+            "$ref": "#/$defs/fieldReference"
           }
         },
         "additionalProperties": false
@@ -1107,7 +1129,7 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
         "type": "object",
         "minProperties": 1,
         "propertyNames": {
-          "$ref": "#/$defs/fieldPath"
+          "$ref": "#/$defs/fieldReference"
         },
         "additionalProperties": {
           "$ref": "#/$defs/linkRule"
@@ -1158,7 +1180,7 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
           ],
           "properties": {
             "field": {
-              "$ref": "#/$defs/fieldPath"
+              "$ref": "#/$defs/fieldReference"
             },
             "scope": {
               "enum": [
@@ -1285,7 +1307,7 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
             "type": "object",
             "minProperties": 1,
             "propertyNames": {
-              "$ref": "#/$defs/fieldPath"
+              "$ref": "#/$defs/fieldReference"
             },
             "additionalProperties": {
               "$ref": "#/$defs/lifecycleValue"
@@ -1351,7 +1373,7 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
             ],
             "properties": {
               "slugify": {
-                "$ref": "#/$defs/fieldPath"
+                "$ref": "#/$defs/fieldReference"
               }
             },
             "additionalProperties": false
@@ -1363,7 +1385,7 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
             ],
             "properties": {
               "copy": {
-                "$ref": "#/$defs/fieldPath"
+                "$ref": "#/$defs/fieldReference"
               }
             },
             "additionalProperties": false
@@ -1475,10 +1497,10 @@ export const GENERATED_CANONICAL_SCHEMAS: Record<string, Record<string, unknown>
           "fields": {
             "type": "object",
             "propertyNames": {
-              "$ref": "#/$defs/fieldPath"
+              "$ref": "#/$defs/fieldReference"
             },
             "additionalProperties": {
-              "$ref": "#/$defs/fieldPath"
+              "$ref": "#/$defs/fieldReference"
             }
           },
           "binding": {

--- a/schemas/v0.3/type-file.schema.json
+++ b/schemas/v0.3/type-file.schema.json
@@ -65,7 +65,26 @@
     },
     "jsonPointer": {
       "type": "string",
+      "format": "json-pointer",
       "pattern": "^(/([^/~]|~0|~1)*)*$"
+    },
+    "fieldReference": {
+      "description": "A legacy mdbase field path or a non-root RFC 6901 JSON Pointer.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/fieldPath"
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/jsonPointer"
+            },
+            {
+              "minLength": 1
+            }
+          ]
+        }
+      ]
     },
     "jsonSchema": {
       "type": "object",
@@ -126,7 +145,7 @@
           "type": "array",
           "minItems": 1,
           "items": {
-            "$ref": "#/$defs/fieldPath"
+            "$ref": "#/$defs/fieldReference"
           },
           "uniqueItems": true
         },
@@ -142,6 +161,9 @@
     "matchWhere": {
       "type": "object",
       "minProperties": 1,
+      "propertyNames": {
+        "$ref": "#/$defs/fieldReference"
+      },
       "additionalProperties": {
         "$ref": "#/$defs/matchPredicate"
       }
@@ -230,16 +252,16 @@
       "type": "object",
       "properties": {
         "name_field": {
-          "$ref": "#/$defs/fieldPath"
+          "$ref": "#/$defs/fieldReference"
         },
         "description_field": {
-          "$ref": "#/$defs/fieldPath"
+          "$ref": "#/$defs/fieldReference"
         },
         "icon": {
           "type": "string"
         },
         "color_field": {
-          "$ref": "#/$defs/fieldPath"
+          "$ref": "#/$defs/fieldReference"
         }
       },
       "additionalProperties": false
@@ -248,7 +270,7 @@
       "type": "object",
       "minProperties": 1,
       "propertyNames": {
-        "$ref": "#/$defs/fieldPath"
+        "$ref": "#/$defs/fieldReference"
       },
       "additionalProperties": {
         "$ref": "#/$defs/linkRule"
@@ -292,7 +314,7 @@
         "required": ["field"],
         "properties": {
           "field": {
-            "$ref": "#/$defs/fieldPath"
+            "$ref": "#/$defs/fieldReference"
           },
           "scope": {
             "enum": ["collection", "type", "path_glob"]
@@ -407,7 +429,7 @@
           "type": "object",
           "minProperties": 1,
           "propertyNames": {
-            "$ref": "#/$defs/fieldPath"
+            "$ref": "#/$defs/fieldReference"
           },
           "additionalProperties": {
             "$ref": "#/$defs/lifecycleValue"
@@ -463,7 +485,7 @@
           "required": ["slugify"],
           "properties": {
             "slugify": {
-              "$ref": "#/$defs/fieldPath"
+              "$ref": "#/$defs/fieldReference"
             }
           },
           "additionalProperties": false
@@ -473,7 +495,7 @@
           "required": ["copy"],
           "properties": {
             "copy": {
-              "$ref": "#/$defs/fieldPath"
+              "$ref": "#/$defs/fieldReference"
             }
           },
           "additionalProperties": false
@@ -568,10 +590,10 @@
         "fields": {
           "type": "object",
           "propertyNames": {
-            "$ref": "#/$defs/fieldPath"
+            "$ref": "#/$defs/fieldReference"
           },
           "additionalProperties": {
-            "$ref": "#/$defs/fieldPath"
+            "$ref": "#/$defs/fieldReference"
           }
         },
         "binding": {

--- a/scripts/check_v03_tests.py
+++ b/scripts/check_v03_tests.py
@@ -656,7 +656,10 @@ def run_data_contract_implementation_test(
     fields = implementation.get("fields") or {}
     required = contract_schema.get("required") or []
     for field_name in required:
-        if field_name not in fields:
+        if not any(
+            field_reference_targets_top_level(contract_field, field_name)
+            for contract_field in fields
+        ):
             failures.append(f"required contract field is not mapped: {field_name}")
 
     for contract_field, record_field in fields.items():
@@ -683,15 +686,11 @@ def run_data_contract_implementation_test(
             record = load_markdown_frontmatter(record_path)
         else:
             record = load_yaml(record_path)
-        view = {
-            contract_field: record[record_field]
-            for contract_field, record_field in fields.items()
-            if "." not in contract_field
-            and "[]" not in contract_field
-            and "." not in record_field
-            and "[]" not in record_field
-            and record_field in record
-        }
+        view: dict[str, Any] = {}
+        for contract_field, record_field in fields.items():
+            found, value = get_field_reference(record, record_field)
+            if found:
+                set_field_reference(view, contract_field, value)
         failures.extend(
             f"record: {error.message}"
             for error in Draft202012Validator(contract_schema).iter_errors(view)
@@ -755,16 +754,88 @@ def data_contract_implementation_digest(
     return "sha256:" + hashlib.sha256(canonical).hexdigest()
 
 
-def schema_declares_field(schema: dict[str, Any], field_path: str) -> bool:
+def parse_field_reference(field_reference: str) -> list[tuple[str, bool]]:
+    if field_reference.startswith("/"):
+        return [
+            (part.replace("~1", "/").replace("~0", "~"), False)
+            for part in field_reference[1:].split("/")
+        ]
+    return [
+        (part[:-2], True) if part.endswith("[]") else (part, False)
+        for part in field_reference.split(".")
+    ]
+
+
+def field_reference_targets_top_level(field_reference: str, field_name: str) -> bool:
+    return parse_field_reference(field_reference) == [(field_name, False)]
+
+
+def schema_declares_field(schema: dict[str, Any], field_reference: str) -> bool:
     current: Any = schema
-    for part in field_path.replace("[]", "").split("."):
+    pointer = field_reference.startswith("/")
+    for part, expands_array in parse_field_reference(field_reference):
+        if pointer and isinstance(current, dict) and current.get("type") == "array":
+            if not part.isdigit() or "items" not in current:
+                return False
+            current = current["items"]
+            continue
         properties = current.get("properties") if isinstance(current, dict) else None
         if not isinstance(properties, dict) or part not in properties:
             return False
         current = properties[part]
-        if "[]" in field_path and isinstance(current, dict) and "items" in current:
+        if expands_array:
+            if not isinstance(current, dict) or "items" not in current:
+                return False
             current = current["items"]
     return True
+
+
+def get_field_reference(source: Any, field_reference: str) -> tuple[bool, Any]:
+    current = source
+    for part, expands_array in parse_field_reference(field_reference):
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        elif (
+            field_reference.startswith("/")
+            and isinstance(current, list)
+            and part.isdigit()
+            and int(part) < len(current)
+        ):
+            current = current[int(part)]
+        else:
+            return False, None
+        if expands_array and not isinstance(current, list):
+            return False, None
+    return True, current
+
+
+def set_field_reference(
+    target: dict[str, Any], field_reference: str, value: Any
+) -> None:
+    segments = parse_field_reference(field_reference)
+    if any(expands_array for _, expands_array in segments):
+        raise ValueError(f"cannot assign through array selector: {field_reference}")
+    current: Any = target
+    for index, (part, _) in enumerate(segments):
+        last = index == len(segments) - 1
+        if isinstance(current, dict):
+            if last:
+                current[part] = value
+                return
+            current = current.setdefault(part, {})
+            continue
+        if (
+            field_reference.startswith("/")
+            and isinstance(current, list)
+            and part.isdigit()
+            and int(part) < len(current)
+        ):
+            if last:
+                current[int(part)] = value
+                return
+            current = current[int(part)]
+            continue
+        raise ValueError(f"cannot assign field reference: {field_reference}")
 
 
 def assert_expected_validation_result(failures: list[str], expect: dict[str, Any]) -> None:

--- a/tests/v0.3/core/core-collection.yaml
+++ b/tests/v0.3/core/core-collection.yaml
@@ -88,6 +88,24 @@ groups:
                 title: { type: string }
                 reviewStatus: { enum: [pending, approved] }
           ---
+        jsonld-contact.md: |
+          ---
+          kind: mdbase.type
+          name: jsonld_contact
+          version: 1
+          match:
+            fields_present: ["/@type"]
+            where:
+              "/@type": Contact
+          schema:
+            dialect: json-schema-2020-12
+            value:
+              type: object
+              required: ["@type", name]
+              properties:
+                "@type": { const: Contact }
+                name: { type: string }
+          ---
         referenced.schema.json: |
           {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -277,6 +295,11 @@ groups:
         notes/review.md: |
           ---
           title: Needs independent review validation
+          ---
+        contacts/ada.md: |
+          ---
+          "@type": Contact
+          name: Ada Lovelace
           ---
         refs/valid.md: |
           ---
@@ -595,6 +618,14 @@ groups:
         expect:
           valid: true
           types: [publishable]
+
+      - name: "JSON Pointer addresses JSON-LD keys in inferred match rules"
+        operation: get_types
+        input:
+          path: "contacts/ada.md"
+        expect:
+          valid: true
+          types: [jsonld_contact]
 
       - name: "explicit type declaration skips inferred match rules"
         id: core.explicit_matching

--- a/tests/v0.3/data-contracts/data-contracts.yaml
+++ b/tests/v0.3/data-contracts/data-contracts.yaml
@@ -32,6 +32,15 @@ groups:
         covers:
           - core_read.data_contract_projection
 
+      - name: "JSON Pointer maps JSON-LD and escaped property names"
+        operation: data_contract_implementation_validate
+        input:
+          contract: "tests/v0.3/fixtures/data-contracts/json-pointer-contact.contract.md"
+          type: "tests/v0.3/fixtures/data-contracts/json-pointer-contact-type.md"
+          record: "tests/v0.3/fixtures/data-contracts/json-pointer-contact.yml"
+        expect:
+          valid: true
+
       - name: "binding schema rejects incomplete semantic configuration"
         operation: data_contract_implementation_validate
         input:

--- a/tests/v0.3/fixtures/data-contracts/json-pointer-contact-type.md
+++ b/tests/v0.3/fixtures/data-contracts/json-pointer-contact-type.md
@@ -1,0 +1,31 @@
+---
+kind: mdbase.type
+name: contact_card
+version: 1
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+    required: [card]
+    properties:
+      card:
+        type: object
+        required: ["@type", label, "a/b", "a~b"]
+        properties:
+          "@type":
+            const: Contact
+          label:
+            type: string
+          "a/b":
+            type: string
+          "a~b":
+            type: string
+implements:
+  - contract: example.typed-contact
+    version: 1.0.0
+    fields:
+      "/@type": "/card/@type"
+      name: "/card/label"
+      "/a~1b": "/card/a~1b"
+      "/a~0b": "/card/a~0b"
+---

--- a/tests/v0.3/fixtures/data-contracts/json-pointer-contact.contract.md
+++ b/tests/v0.3/fixtures/data-contracts/json-pointer-contact.contract.md
@@ -1,0 +1,19 @@
+---
+kind: mdbase.contract
+id: example.typed-contact
+version: 1.0.0
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+    required: ["@type", name, "a/b", "a~b"]
+    properties:
+      "@type":
+        const: Contact
+      name:
+        type: string
+      "a/b":
+        type: string
+      "a~b":
+        type: string
+---

--- a/tests/v0.3/fixtures/data-contracts/json-pointer-contact.yml
+++ b/tests/v0.3/fixtures/data-contracts/json-pointer-contact.yml
@@ -1,0 +1,5 @@
+card:
+  "@type": Contact
+  label: Ada Lovelace
+  "a/b": slash
+  "a~b": tilde


### PR DESCRIPTION
## Summary
- allow field references to use RFC 6901 JSON Pointers alongside legacy dot paths
- make every collection selector and data-contract mapping consume the shared field-reference definition
- document pointer semantics and add conformance fixtures covering `@type`, nesting, and escaped tokens

## Validation
- `python3 scripts/check_v03_tests.py` (55 executable tests, 94 adapter-target tests)
- `npm test` in `packages/runtime-contracts` (20 tests)