### PR TITLE
Add the portable interoperability testbed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,39 @@ jobs:
           npm --prefix packages/runtime-executor ci
           npm --prefix packages/runtime-executor test
 
+  interoperability-testbed:
+    name: interoperability testbed (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            packages/interop/package-lock.json
+            packages/testbed/package-lock.json
+      - name: Install reference interoperability sources
+        working-directory: packages/interop
+        run: npm ci
+      - name: Install testbed
+        working-directory: packages/testbed
+        run: npm ci
+      - name: Run black-box reference scenarios
+        working-directory: packages/testbed
+        run: npm test
+      - name: Verify generated package assets
+        run: git diff --exit-code -- packages/testbed/assets
+      - name: Verify package contents
+        working-directory: packages/testbed
+        run: npm pack --dry-run
+
   site-artifact:
     name: specification site artifact
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,6 @@ __pycache__/
 /.ops/
 /packages/interop/node_modules/
 /packages/interop/dist/
+/packages/testbed/node_modules/
+/packages/testbed/dist/
 /packages/interop-rs/target/

--- a/00-overview.md
+++ b/00-overview.md
@@ -289,6 +289,11 @@ testable.
 | [15-migrations-and-compatibility.md](./15-migrations-and-compatibility.md) | Migration from earlier versions and compatibility |
 | [16-conformance.md](./16-conformance.md) | Profiles, claims, fixtures, and runners |
 
+The [portable interoperability testbed](/testbed/) runs neutral contract,
+event/action, and durable-runtime scenarios through black-box adapters. Its
+canonical transcripts make cross-language and cross-application behavior
+directly comparable without making one product's internal API normative.
+
 ## Versioning
 
 This specification uses semantic versioning. The current version is **0.3.0**.
@@ -296,8 +301,7 @@ Collections declare their specification version with `spec_version` in
 `mdbase.yaml`. Tools declare the profiles and versions they implement.
 
 The optional runtime-contract and workflow vocabulary has an independent
-profile version. The runtime profile defined by this specification is
-**0.1.0**.
+profile version. The runtime profile defined by this specification is **0.2**.
 
 ## Normative Language
 

--- a/16-conformance.md
+++ b/16-conformance.md
@@ -64,6 +64,54 @@ The canonical claim schema enforces profile dependencies. Claim verification
 tools SHOULD reject evidence produced for a different implementation artifact
 or specification version and SHOULD report stale evidence.
 
+### Portable Interoperability Testbed
+
+The spec-owned interoperability testbed in `testbed/v0.1/` supplements the
+profile suites with executable, implementation-neutral integration scenarios.
+It has three rings:
+
+| Ring | Boundary under test |
+| --- | --- |
+| Contract | record contracts, type `implements` declarations, projections, and multiple independent consumers |
+| Interop | live event sources/consumers and action callers/providers connected through the interoperability profile |
+| Runtime | durable admission, action attempts, crash recovery, leases, and fencing |
+
+The testbed is deliberately role-based. An application MAY consume the same
+type or contract as any number of other applications. An event is delivered to
+every compatible authorized subscriber. An action still resolves to exactly one
+admitted provider; multiple eligible providers remain an error until a caller
+or policy selects one. The testbed does not turn an application name into a
+contract owner.
+
+Every testbed scenario MUST validate against
+`schemas/testbed/v0.1/scenario.schema.json`, use only fixtures from the validated
+neutral catalog, and include its canonical expected transcript. An adapter MUST
+run behind the `describe`/`run` process boundary defined by testbed protocol
+`0.1`. A runner MUST start a fresh adapter process for each scenario, validate
+the run request and returned transcript, and compare the complete ordered
+transcript entries. Adapters MUST derive entries from behavior observed through
+public or documented implementation boundaries; copying the scenario's
+expected entries is not a conforming adapter.
+
+Transcripts intentionally contain stable facts rather than private state.
+Generated IDs, database keys, wall-clock values, stack traces, scheduling
+jitter, and implementation-specific objects MUST be normalized or omitted
+unless a scenario explicitly makes them observable. Scenario order, actor,
+operation, outcome, and facts are all significant.
+
+Portable testbed evidence validates against
+`schemas/testbed/v0.1/evidence.schema.json` and binds every scenario result to a
+canonical transcript digest. A conformance claim records it with evidence kind
+`testbed_transcript`, the protocol version, scenario IDs, artifact path, and
+evidence digest. `evidence_digest` MUST be the SHA-256 digest of the evidence
+artifact's recursively key-sorted, whitespace-free JSON form, prefixed with
+`sha256:`. Passing the testbed does not replace the complete profile suite: it
+is integration evidence for the normative requirements named by each scenario.
+
+Conformance never grants authority. A testbed adapter may be able to construct
+a compatible payload or declaration while the real host correctly rejects the
+operation as unauthorized.
+
 ## Canonical Diagnostics
 
 Every diagnostic contains:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ order_by:
 | Define durable automation | [Durable Runtime Companion](./13-runtime-contracts.md), [Workflow Execution](./14-workflows.md), and the [standard runtime pack](./standard-packs/mdbase-runtime/0.2.0/) |
 | Migrate a v0.2 collection | [Migrations And Compatibility](./15-migrations-and-compatibility.md) |
 | Exchange typed events and actions | [Event/action interoperability profile 0.1](./interop/0.1.md) and [canonical interoperability schemas](./schemas/interop/v0.1/) |
-| Build a conforming tool | [Conformance](./16-conformance.md), [first-class contracts](./05-data-contracts.md), [canonical schemas](./schemas/v0.3/), and [test fixtures](./tests/v0.3/) |
+| Build a conforming tool | [Conformance](./16-conformance.md), the [portable interoperability testbed](./testbed/v0.1/), [canonical schemas](./schemas/v0.3/), and [test fixtures](./tests/v0.3/) |
 
 ## Implementations
 
@@ -157,7 +157,8 @@ implementer material. Legacy fixtures are documented in
 - [`tests/v0.3/`](./tests/v0.3/) contains shared conformance fixtures.
 - [`examples/v0.3/`](./examples/v0.3/) contains example and migration
   collections.
-- [`packages/`](./packages/) contains CEL and runtime support packages.
+- [`packages/`](./packages/) contains CEL, runtime, interoperability, and
+  black-box testbed support packages.
 - [`standard-packs/`](./standard-packs/) contains inspectable, transactional
   standard-library distributions such as the durable runtime pack.
 - [`site/`](./site/) builds the versioned specification reader imported by the
@@ -176,6 +177,7 @@ npm test --prefix packages/runtime-contracts
 cargo test --manifest-path packages/runtime-contracts-rs/Cargo.toml
 npm test --prefix packages/cel-host
 npm test --prefix packages/runtime-executor
+npm test --prefix packages/testbed
 npm run build --prefix site
 ```
 

--- a/packages/testbed/LICENSE
+++ b/packages/testbed/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Callum Alpass
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/testbed/README.md
+++ b/packages/testbed/README.md
@@ -1,0 +1,35 @@
+# `@callumalpass/mdbase-testbed`
+
+This package runs the portable mdbase interoperability testbed through a
+black-box process adapter. The same JSON scenarios and canonical transcripts
+are used for TypeScript, Rust, desktop, server, and plugin integrations.
+
+```bash
+npx @callumalpass/mdbase-testbed validate
+npx @callumalpass/mdbase-testbed run --adapter reference
+npx @callumalpass/mdbase-testbed run --adapter ./my-adapter
+```
+
+Language launchers are supported without a shell. For example:
+
+```bash
+mdbase-testbed run --adapter command:cargo \
+  --adapter-arg run --adapter-arg --quiet \
+  --adapter-arg -p --adapter-arg mdbase-testbed-adapter --adapter-arg --
+```
+
+An adapter implements `describe` and `run`, reads a run request from standard
+input, and writes one validated transcript to standard output. See the
+[testbed protocol](https://mdbase.dev/testbed/v0.1/README.md). The
+`mdbase-testbed-reference` binary is a bundled executable example.
+
+The runner:
+
+- validates every scenario, fixture, adapter description, request, transcript,
+  and evidence document against Draft 2020-12 JSON Schema;
+- starts a fresh adapter process for each scenario;
+- compares only stable observable transcript entries;
+- can emit digest-bound evidence with `--evidence <path>`.
+
+Passing these scenarios is supplemental evidence. A complete profile claim
+still requires every normative conformance test named by that profile.

--- a/packages/testbed/adapters/reference.mjs
+++ b/packages/testbed/adapters/reference.mjs
@@ -1,0 +1,502 @@
+#!/usr/bin/env node
+
+import {
+  InMemoryInteropBridge,
+  InteropError,
+  contractDigest
+} from "../../interop/src/index.ts";
+
+const implementation = {
+  id: "mdbase-interop.typescript.reference",
+  name: "mdbase TypeScript in-memory interoperability bridge",
+  version: "0.1.0-rc.2",
+  language: "TypeScript",
+  target: "Node.js"
+};
+
+const scenarios = [
+  "interop.action-ambiguous",
+  "interop.action-explicit-provider",
+  "interop.action-single-provider",
+  "interop.authority-boundary",
+  "interop.contract-digest-drift",
+  "interop.event-multicast",
+  "interop.invalid-payload",
+  "interop.provider-disappearance",
+  "interop.request-replay"
+];
+
+const command = process.argv[2];
+if (command === "describe") {
+  write({
+    kind: "mdbase.testbed.adapter",
+    protocol_version: "0.1",
+    implementation,
+    profiles: ["event_action_interop/0.1"],
+    roles: [
+      "event_source",
+      "event_consumer",
+      "action_caller",
+      "action_provider",
+      "bridge"
+    ],
+    scenarios
+  });
+} else if (command === "run") {
+  try {
+    const request = JSON.parse(await readStdin());
+    if (
+      request.kind !== "mdbase.testbed.run"
+      || request.protocol_version !== "0.1"
+      || !scenarios.includes(request.scenario?.id)
+    ) {
+      throw new Error("Unsupported or invalid mdbase testbed run request.");
+    }
+    const entries = await runScenario(request);
+    write({
+      kind: "mdbase.testbed.transcript",
+      protocol_version: "0.1",
+      scenario_id: request.scenario.id,
+      implementation,
+      entries
+    });
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+    process.exitCode = 1;
+  }
+} else {
+  process.stderr.write("Usage: reference.mjs describe|run\n");
+  process.exitCode = 2;
+}
+
+async function runScenario(request) {
+  switch (request.scenario.id) {
+    case "interop.event-multicast":
+      return await eventMulticast(fixture(request, "contract.record-changed"));
+    case "interop.action-single-provider":
+      return await actionSingleProvider(fixture(request, "contract.record-annotate"));
+    case "interop.action-ambiguous":
+      return await actionAmbiguous(fixture(request, "contract.record-annotate"));
+    case "interop.action-explicit-provider":
+      return await actionExplicitProvider(fixture(request, "contract.record-annotate"));
+    case "interop.provider-disappearance":
+      return await providerDisappearance(fixture(request, "contract.record-annotate"));
+    case "interop.contract-digest-drift":
+      return await contractDigestDrift(fixture(request, "contract.record-changed"));
+    case "interop.invalid-payload":
+      return await invalidPayload(
+        fixture(request, "contract.record-changed"),
+        request.scenario.parameters.data
+      );
+    case "interop.authority-boundary":
+      return await authorityBoundary(fixture(request, "contract.record-annotate"));
+    case "interop.request-replay":
+      return await requestReplay(fixture(request, "contract.record-annotate"));
+    default:
+      throw new Error(`Unsupported scenario ${request.scenario.id}.`);
+  }
+}
+
+async function eventMulticast(contract) {
+  const bridge = testBridge();
+  try {
+    const source = bridge.connect(identity("source"));
+    const alpha = bridge.connect(identity("consumer-alpha"));
+    const beta = bridge.connect(identity("consumer-beta"));
+    const received = [];
+    await source.registerEventSource({
+      declaration_id: "source.events",
+      contracts: [{ contract }]
+    });
+    await alpha.subscribeEvents(
+      { contract: { id: contract.id, version: "^1.0.0" } },
+      () => received.push("consumer-alpha")
+    );
+    await beta.subscribeEvents(
+      { contract: { id: contract.id, version: ">=1.0.0 <2.0.0" } },
+      () => received.push("consumer-beta")
+    );
+    const published = await source.publishEvent({
+      id: "evt-shared-1",
+      contract: { id: contract.id, version: contract.version },
+      data: { record_id: "note-1", revision: 1 }
+    });
+    return [
+      entry(1, "arrange", "source", "event-source.register", "succeeded", {
+        contract: contract.id,
+        version: contract.version
+      }),
+      entry(2, "arrange", "consumer-alpha", "event.subscribe", "succeeded", {
+        version: "^1.0.0"
+      }),
+      entry(3, "arrange", "consumer-beta", "event.subscribe", "succeeded", {
+        version: ">=1.0.0 <2.0.0"
+      }),
+      entry(4, "act", "source", "event.publish", "succeeded", {
+        event_id: published.event.id
+      }),
+      entry(5, "observe", "bridge", "event.deliver", "succeeded", {
+        consumers: received,
+        deliveries: published.deliveries,
+        duplicate: published.duplicate,
+        exact_contract:
+          published.event.mdbasecontractversion === contract.version
+          && published.event.mdbasecontractdigest === await contractDigest(contract),
+        specversion: published.event.specversion
+      })
+    ];
+  } finally {
+    await bridge.dispose();
+  }
+}
+
+async function actionSingleProvider(contract) {
+  const bridge = testBridge();
+  try {
+    const calls = { count: 0 };
+    const provider = bridge.connect(identity("provider-alpha"));
+    const caller = bridge.connect(identity("caller"));
+    await registerProvider(provider, contract, calls);
+    const outcome = await caller.invokeAction({
+      request_id: "req-single-1",
+      contract: { id: contract.id, version: "^1.0.0" },
+      idempotency_key: "req-single-1",
+      input: { record_id: "note-1", label: "observed" }
+    });
+    return [
+      entry(1, "arrange", "provider-alpha", "action-provider.register", "succeeded", {
+        contract: contract.id,
+        idempotency: "request"
+      }),
+      entry(2, "act", "caller", "action.invoke", status(outcome), {
+        request_id: outcome.request_id
+      }),
+      entry(3, "observe", "bridge", "action.outcome", status(outcome), {
+        exact_contract:
+          outcome.contract.version === contract.version
+          && outcome.contract.digest === await contractDigest(contract),
+        provider: outcome.provider.application,
+        provider_calls: calls.count,
+        request_id: outcome.request_id
+      })
+    ];
+  } finally {
+    await bridge.dispose();
+  }
+}
+
+async function actionAmbiguous(contract) {
+  const bridge = testBridge();
+  try {
+    const alphaCalls = { count: 0 };
+    const betaCalls = { count: 0 };
+    const caller = bridge.connect(identity("caller"));
+    await registerProvider(
+      bridge.connect(identity("provider-alpha")),
+      contract,
+      alphaCalls
+    );
+    await registerProvider(
+      bridge.connect(identity("provider-beta")),
+      contract,
+      betaCalls
+    );
+    const code = await rejectedCode(() => caller.invokeAction({
+      contract: { id: contract.id, version: "^1.0.0" },
+      idempotency_key: "req-ambiguous-1",
+      input: { record_id: "note-1", label: "observed" }
+    }));
+    return [
+      entry(1, "arrange", "provider-alpha", "action-provider.register", "succeeded", {
+        contract: contract.id
+      }),
+      entry(2, "arrange", "provider-beta", "action-provider.register", "succeeded", {
+        contract: contract.id
+      }),
+      entry(3, "act", "caller", "action.invoke", "rejected", {
+        code,
+        provider_calls: alphaCalls.count + betaCalls.count
+      })
+    ];
+  } finally {
+    await bridge.dispose();
+  }
+}
+
+async function actionExplicitProvider(contract) {
+  const bridge = testBridge();
+  try {
+    const alphaCalls = { count: 0 };
+    const betaCalls = { count: 0 };
+    const caller = bridge.connect(identity("caller"));
+    await registerProvider(
+      bridge.connect(identity("provider-alpha")),
+      contract,
+      alphaCalls
+    );
+    await registerProvider(
+      bridge.connect(identity("provider-beta")),
+      contract,
+      betaCalls
+    );
+    const outcome = await caller.invokeAction({
+      contract: { id: contract.id, version: "^1.0.0" },
+      requested_provider: { application: "provider-beta" },
+      idempotency_key: "req-explicit-1",
+      input: { record_id: "note-1", label: "observed" }
+    });
+    return [
+      entry(1, "arrange", "provider-alpha", "action-provider.register", "succeeded", {
+        contract: contract.id
+      }),
+      entry(2, "arrange", "provider-beta", "action-provider.register", "succeeded", {
+        contract: contract.id
+      }),
+      entry(3, "act", "caller", "action.invoke", status(outcome), {
+        selected: outcome.provider.application
+      }),
+      entry(4, "observe", "bridge", "action.outcome", status(outcome), {
+        provider: outcome.provider.application,
+        provider_alpha_calls: alphaCalls.count,
+        provider_beta_calls: betaCalls.count
+      })
+    ];
+  } finally {
+    await bridge.dispose();
+  }
+}
+
+async function providerDisappearance(contract) {
+  const bridge = testBridge();
+  try {
+    const calls = { count: 0 };
+    const provider = bridge.connect(identity("provider-alpha"));
+    const caller = bridge.connect(identity("caller"));
+    await registerProvider(provider, contract, calls);
+    const before = bridge.describe().action_providers.length;
+    await provider.dispose();
+    const after = bridge.describe().action_providers.length;
+    const code = await rejectedCode(() => caller.invokeAction({
+      contract: { id: contract.id, version: "^1.0.0" },
+      idempotency_key: "req-disappeared-1",
+      input: { record_id: "note-1", label: "observed" }
+    }));
+    return [
+      entry(1, "arrange", "provider-alpha", "action-provider.register", "succeeded", {
+        providers: before
+      }),
+      entry(2, "act", "provider-alpha", "client.dispose", "succeeded", {
+        providers: after
+      }),
+      entry(3, "observe", "caller", "action.invoke", "rejected", {
+        code,
+        provider_calls: calls.count
+      })
+    ];
+  } finally {
+    await bridge.dispose();
+  }
+}
+
+async function contractDigestDrift(contract) {
+  const bridge = testBridge();
+  try {
+    const alpha = bridge.connect(identity("source-alpha"));
+    const beta = bridge.connect(identity("source-beta"));
+    await alpha.registerEventSource({
+      declaration_id: "alpha.events",
+      contracts: [{ contract }]
+    });
+    const drifted = structuredClone(contract);
+    drifted.data_schema.value.properties.record_id.minLength = 2;
+    const code = await rejectedCode(() => beta.registerEventSource({
+      declaration_id: "beta.events",
+      contracts: [{ contract: drifted }]
+    }));
+    const sources = bridge.describe().event_sources.length;
+    return [
+      entry(1, "arrange", "source-alpha", "event-source.register", "succeeded", {
+        sources: 1
+      }),
+      entry(2, "act", "source-beta", "event-source.register", "rejected", {
+        code
+      }),
+      entry(3, "observe", "bridge", "registry.inspect", "succeeded", {
+        atomic: sources === 1,
+        sources
+      })
+    ];
+  } finally {
+    await bridge.dispose();
+  }
+}
+
+async function invalidPayload(contract, data) {
+  const bridge = testBridge();
+  try {
+    const source = bridge.connect(identity("source"));
+    const consumer = bridge.connect(identity("consumer"));
+    let deliveries = 0;
+    await source.registerEventSource({
+      declaration_id: "source.events",
+      contracts: [{ contract }]
+    });
+    await consumer.subscribeEvents(
+      { contract: { id: contract.id, version: "^1.0.0" } },
+      () => { deliveries += 1; }
+    );
+    const code = await rejectedCode(() => source.publishEvent({
+      contract: { id: contract.id, version: contract.version },
+      data
+    }));
+    return [
+      entry(1, "arrange", "source", "event-source.register", "succeeded", {
+        contract: contract.id
+      }),
+      entry(2, "arrange", "consumer", "event.subscribe", "succeeded", {
+        version: "^1.0.0"
+      }),
+      entry(3, "act", "source", "event.publish", "rejected", { code }),
+      entry(4, "observe", "consumer", "event.deliver", "skipped", { deliveries })
+    ];
+  } finally {
+    await bridge.dispose();
+  }
+}
+
+async function authorityBoundary(contract) {
+  const bridge = testBridge({
+    authorize: ({ operation, principal }) =>
+      operation !== "register_action_provider"
+      || principal.application !== "untrusted-provider"
+  });
+  try {
+    const provider = bridge.connect(identity("untrusted-provider"));
+    const digest = await contractDigest(contract);
+    const code = await rejectedCode(() => registerProvider(
+      provider,
+      contract,
+      { count: 0 }
+    ));
+    return [
+      entry(1, "arrange", "untrusted-provider", "contract.validate", "succeeded", {
+        contract: digest.startsWith("sha256:") ? contract.id : ""
+      }),
+      entry(2, "act", "untrusted-provider", "action-provider.register", "rejected", {
+        code
+      }),
+      entry(3, "observe", "bridge", "registry.inspect", "succeeded", {
+        providers: bridge.describe().action_providers.length
+      })
+    ];
+  } finally {
+    await bridge.dispose();
+  }
+}
+
+async function requestReplay(contract) {
+  const bridge = testBridge();
+  try {
+    const calls = { count: 0 };
+    const provider = bridge.connect(identity("provider-alpha"));
+    const caller = bridge.connect(identity("caller"));
+    await registerProvider(provider, contract, calls);
+    const request = {
+      request_id: "req-replay-1",
+      contract: { id: contract.id, version: contract.version },
+      idempotency_key: "run-1:annotate",
+      input: { record_id: "note-1", label: "observed" }
+    };
+    const first = await caller.invokeAction(request);
+    const second = await caller.invokeAction(request);
+    return [
+      entry(1, "arrange", "provider-alpha", "action-provider.register", "succeeded", {
+        idempotency: "request"
+      }),
+      entry(2, "act", "caller", "action.invoke", status(first), {
+        request_id: first.request_id
+      }),
+      entry(3, "act", "caller", "action.replay", status(second), {
+        request_id: second.request_id
+      }),
+      entry(4, "observe", "bridge", "action.outcome", status(second), {
+        handler_calls: calls.count,
+        same_outcome: JSON.stringify(first) === JSON.stringify(second)
+      })
+    ];
+  } finally {
+    await bridge.dispose();
+  }
+}
+
+async function registerProvider(client, contract, calls) {
+  return await client.registerActionProvider({
+    declaration_id: `${client.identity?.application ?? "provider"}.actions`,
+    handlers: [{
+      handler_id: "annotate",
+      contract,
+      idempotency: { mode: "request", retention_seconds: 60 },
+      cancellation: "cooperative",
+      handler: async ({ record_id }) => {
+        calls.count += 1;
+        return { record_id, applied: true };
+      }
+    }]
+  });
+}
+
+function testBridge(options = {}) {
+  let nextId = 0;
+  return new InMemoryInteropBridge({
+    authorize: () => true,
+    now: () => new Date("2026-07-29T00:00:00.000Z"),
+    idFactory: (prefix) => `${prefix}_${++nextId}`,
+    ...options
+  });
+}
+
+function identity(application) {
+  return {
+    application,
+    implementation: `${application}.testbed`,
+    version: "1.0.0",
+    instance_id: `${application}-instance`
+  };
+}
+
+function fixture(request, id) {
+  const fixtureValue = request.fixtures?.[id];
+  if (!fixtureValue) throw new Error(`Scenario request is missing fixture ${id}.`);
+  return structuredClone(fixtureValue.value);
+}
+
+function entry(sequence, phase, actor, operation, outcome, facts) {
+  return { sequence, phase, actor, operation, outcome, facts };
+}
+
+function status(outcome) {
+  if (outcome.status === "succeeded") return "succeeded";
+  if (outcome.status === "outcome_indeterminate") return "indeterminate";
+  if (outcome.status === "rejected") return "rejected";
+  return "failed";
+}
+
+async function rejectedCode(operation) {
+  try {
+    await operation();
+  } catch (error) {
+    if (error instanceof InteropError) return error.code;
+    throw error;
+  }
+  throw new Error("Expected interoperability operation to reject.");
+}
+
+async function readStdin() {
+  let source = "";
+  for await (const chunk of process.stdin) source += chunk;
+  return source;
+}
+
+function write(value) {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}

--- a/packages/testbed/assets/schemas/README.md
+++ b/packages/testbed/assets/schemas/README.md
@@ -1,0 +1,15 @@
+# mdbase interoperability testbed schemas
+
+These Draft 2020-12 schemas define portable testbed protocol `0.1`:
+
+- `scenario.schema.json` validates neutral, spec-owned scenario definitions.
+- `fixture-catalog.schema.json` validates the shared input catalog.
+- `adapter-description.schema.json` validates the capabilities reported by a
+  black-box adapter.
+- `run-request.schema.json` validates the complete input sent to an adapter.
+- `transcript.schema.json` validates deterministic observable results.
+- `evidence.schema.json` validates the digest-bound run summary suitable for a
+  conformance claim.
+
+The process protocol and conformance rules are defined in
+[`testbed/v0.1/README.md`](../../../testbed/v0.1/README.md).

--- a/packages/testbed/assets/schemas/adapter-description.schema.json
+++ b/packages/testbed/assets/schemas/adapter-description.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/testbed/v0.1/adapter-description.schema.json",
+  "title": "mdbase interoperability testbed adapter description",
+  "type": "object",
+  "required": [
+    "kind",
+    "protocol_version",
+    "implementation",
+    "profiles",
+    "roles",
+    "scenarios"
+  ],
+  "properties": {
+    "kind": { "const": "mdbase.testbed.adapter" },
+    "protocol_version": { "const": "0.1" },
+    "implementation": {
+      "type": "object",
+      "required": ["id", "name", "version"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[A-Za-z][A-Za-z0-9._:/-]*$"
+        },
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "language": { "type": "string", "minLength": 1 },
+        "target": { "type": "string", "minLength": 1 }
+      },
+      "patternProperties": {
+        "^x-[A-Za-z0-9._:-]+$": true
+      },
+      "additionalProperties": false
+    },
+    "profiles": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "core_read",
+          "event_action_interop/0.1",
+          "runtime/0.2"
+        ]
+      }
+    },
+    "roles": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "contract_store",
+          "record_consumer",
+          "event_source",
+          "event_consumer",
+          "action_caller",
+          "action_provider",
+          "bridge",
+          "runtime",
+          "runtime_store"
+        ]
+      }
+    },
+    "scenarios": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/testbed/assets/schemas/evidence.schema.json
+++ b/packages/testbed/assets/schemas/evidence.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/testbed/v0.1/evidence.schema.json",
+  "title": "mdbase interoperability testbed evidence",
+  "type": "object",
+  "required": [
+    "kind",
+    "protocol_version",
+    "implementation",
+    "result",
+    "scenarios"
+  ],
+  "properties": {
+    "kind": { "const": "mdbase.testbed.evidence" },
+    "protocol_version": { "const": "0.1" },
+    "implementation": {
+      "$ref": "adapter-description.schema.json#/properties/implementation"
+    },
+    "result": { "enum": ["pass", "fail"] },
+    "scenarios": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "profile", "result", "transcript_digest"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+          },
+          "profile": {
+            "enum": [
+              "core_read",
+              "event_action_interop/0.1",
+              "runtime/0.2"
+            ]
+          },
+          "result": { "enum": ["pass", "fail"] },
+          "transcript_digest": {
+            "type": "string",
+            "pattern": "^sha256:[0-9a-f]{64}$"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/testbed/assets/schemas/fixture-catalog.schema.json
+++ b/packages/testbed/assets/schemas/fixture-catalog.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/testbed/v0.1/fixture-catalog.schema.json",
+  "title": "mdbase interoperability testbed fixture catalog",
+  "type": "object",
+  "required": ["kind", "protocol_version", "fixtures"],
+  "properties": {
+    "kind": { "const": "mdbase.testbed.fixtures" },
+    "protocol_version": { "const": "0.1" },
+    "fixtures": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "required": ["kind", "value"],
+        "properties": {
+          "kind": {
+            "enum": ["contract", "type", "record", "workflow", "policy"]
+          },
+          "value": {}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/testbed/assets/schemas/run-request.schema.json
+++ b/packages/testbed/assets/schemas/run-request.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/testbed/v0.1/run-request.schema.json",
+  "title": "mdbase interoperability testbed run request",
+  "type": "object",
+  "required": ["kind", "protocol_version", "scenario", "fixtures"],
+  "properties": {
+    "kind": { "const": "mdbase.testbed.run" },
+    "protocol_version": { "const": "0.1" },
+    "scenario": {
+      "$ref": "scenario.schema.json"
+    },
+    "fixtures": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["kind", "value"],
+        "properties": {
+          "kind": {
+            "enum": ["contract", "type", "record", "workflow", "policy"]
+          },
+          "value": {}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/testbed/assets/schemas/scenario.schema.json
+++ b/packages/testbed/assets/schemas/scenario.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/testbed/v0.1/scenario.schema.json",
+  "title": "mdbase interoperability testbed scenario",
+  "type": "object",
+  "required": [
+    "kind",
+    "protocol_version",
+    "id",
+    "name",
+    "ring",
+    "profile",
+    "roles",
+    "operation",
+    "fixtures",
+    "parameters",
+    "covers",
+    "expect"
+  ],
+  "properties": {
+    "kind": { "const": "mdbase.testbed.scenario" },
+    "protocol_version": { "const": "0.1" },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+    },
+    "name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "ring": {
+      "enum": ["contract", "interop", "runtime"]
+    },
+    "profile": {
+      "enum": [
+        "core_read",
+        "event_action_interop/0.1",
+        "runtime/0.2"
+      ]
+    },
+    "roles": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "contract_store",
+          "record_consumer",
+          "event_source",
+          "event_consumer",
+          "action_caller",
+          "action_provider",
+          "bridge",
+          "runtime",
+          "runtime_store"
+        ]
+      }
+    },
+    "operation": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+    },
+    "fixtures": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+      }
+    },
+    "parameters": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "covers": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9._/-]+$"
+      }
+    },
+    "expect": {
+      "type": "object",
+      "required": ["entries"],
+      "properties": {
+        "entries": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/transcriptEntry"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "transcriptEntry": {
+      "type": "object",
+      "required": [
+        "sequence",
+        "phase",
+        "actor",
+        "operation",
+        "outcome",
+        "facts"
+      ],
+      "properties": {
+        "sequence": { "type": "integer", "minimum": 1 },
+        "phase": {
+          "enum": ["arrange", "act", "observe", "recover"]
+        },
+        "actor": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$"
+        },
+        "operation": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+        },
+        "outcome": {
+          "enum": [
+            "succeeded",
+            "rejected",
+            "failed",
+            "indeterminate",
+            "skipped"
+          ]
+        },
+        "facts": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/testbed/assets/schemas/transcript.schema.json
+++ b/packages/testbed/assets/schemas/transcript.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/testbed/v0.1/transcript.schema.json",
+  "title": "mdbase interoperability testbed transcript",
+  "type": "object",
+  "required": [
+    "kind",
+    "protocol_version",
+    "scenario_id",
+    "implementation",
+    "entries"
+  ],
+  "properties": {
+    "kind": { "const": "mdbase.testbed.transcript" },
+    "protocol_version": { "const": "0.1" },
+    "scenario_id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+    },
+    "implementation": {
+      "type": "object",
+      "required": ["id", "name", "version"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[A-Za-z][A-Za-z0-9._:/-]*$"
+        },
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "language": { "type": "string", "minLength": 1 },
+        "target": { "type": "string", "minLength": 1 }
+      },
+      "patternProperties": {
+        "^x-[A-Za-z0-9._:-]+$": true
+      },
+      "additionalProperties": false
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/entry" }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "required": [
+        "sequence",
+        "phase",
+        "actor",
+        "operation",
+        "outcome",
+        "facts"
+      ],
+      "properties": {
+        "sequence": { "type": "integer", "minimum": 1 },
+        "phase": {
+          "enum": ["arrange", "act", "observe", "recover"]
+        },
+        "actor": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$"
+        },
+        "operation": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+        },
+        "outcome": {
+          "enum": [
+            "succeeded",
+            "rejected",
+            "failed",
+            "indeterminate",
+            "skipped"
+          ]
+        },
+        "facts": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/testbed/assets/suite/README.md
+++ b/packages/testbed/assets/suite/README.md
@@ -1,0 +1,87 @@
+# mdbase interoperability testbed 0.1
+
+The testbed verifies observable behavior through a small process boundary. It
+does not require implementations to share a language, runtime, database, or
+plugin host, and it does not make fixture code authoritative.
+
+## The three rings
+
+1. **Contract** — load one record contract and type implementation, project one
+   record, and prove that multiple independent consumers receive the same
+   contract view.
+2. **Interop** — register live sources, consumers, callers, and providers; then
+   verify CloudEvents multicast, exact action admission, ambiguity, unload,
+   validation, authorization, and replay behavior.
+3. **Runtime** — exercise a durable store through crash recovery and competing
+   workers, including invocation reuse and lease fencing.
+
+Scenario JSON, not a particular implementation, defines the oracle. Every
+scenario names neutral fixtures from `fixtures/catalog.json` and contains its
+complete expected transcript. Volatile implementation details such as database
+keys, wall-clock time, and generated IDs are reduced to stable facts before
+comparison.
+
+## Adapter process protocol
+
+An adapter is an executable supporting two commands:
+
+```text
+adapter describe
+adapter run
+```
+
+`describe` writes one JSON document conforming to
+`adapter-description.schema.json`. For `run`, the testbed writes this JSON
+request to standard input:
+
+```json
+{
+  "kind": "mdbase.testbed.run",
+  "protocol_version": "0.1",
+  "scenario": {},
+  "fixtures": {}
+}
+```
+
+The adapter writes one transcript conforming to `transcript.schema.json`.
+Diagnostic logging belongs on standard error; standard output contains only the
+protocol document. Each `run` command is a fresh process, so scenarios cannot
+pass because of hidden state left by another scenario.
+
+Adapters MUST exercise public or documented implementation boundaries. They
+MUST NOT copy the expected transcript without observing the behavior it
+describes. A transcript is evidence of a named scenario, not authority to read,
+write, publish, subscribe, invoke, or provide.
+
+## Running
+
+From this repository:
+
+```bash
+npm test --prefix packages/testbed
+npm exec --prefix packages/testbed mdbase-testbed -- run --adapter reference
+```
+
+Against another implementation:
+
+```bash
+mdbase-testbed run --adapter ./path/to/adapter
+```
+
+If the adapter is launched through a language tool, use `command:NAME` and pass
+its fixed arguments separately. The runner never invokes a shell:
+
+```bash
+mdbase-testbed run --adapter command:cargo \
+  --adapter-arg run --adapter-arg --quiet \
+  --adapter-arg -p --adapter-arg my-testbed-adapter --adapter-arg --
+```
+
+Use `mdbase-testbed list` to inspect the portable scenario inventory and
+`mdbase-testbed validate` to validate every schema, fixture, scenario, and
+canonical expected transcript.
+
+Passing the testbed supplements the full v0.3 conformance suites. It does not by
+itself establish a complete profile claim: implementations still run every
+normative test for the profile they claim and attach the testbed transcript as
+machine-readable evidence.

--- a/packages/testbed/assets/suite/fixtures/catalog.json
+++ b/packages/testbed/assets/suite/fixtures/catalog.json
@@ -1,0 +1,175 @@
+{
+  "kind": "mdbase.testbed.fixtures",
+  "protocol_version": "0.1",
+  "fixtures": {
+    "contract.example-note": {
+      "kind": "contract",
+      "value": {
+        "kind": "mdbase.contract",
+        "contract_type": "record",
+        "id": "example.note",
+        "version": "1.0.0",
+        "name": "Portable example note",
+        "record_schema": {
+          "dialect": "json-schema-2020-12",
+          "value": {
+            "type": "object",
+            "required": ["title"],
+            "additionalProperties": false,
+            "properties": {
+              "title": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    "type.shared-note": {
+      "kind": "type",
+      "value": {
+        "kind": "mdbase.type",
+        "name": "shared_note",
+        "version": 1,
+        "schema": {
+          "dialect": "json-schema-2020-12",
+          "value": {
+            "type": "object",
+            "required": ["type", "headline"],
+            "properties": {
+              "type": { "const": "shared_note" },
+              "headline": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "implements": [
+          {
+            "contract": "example.note",
+            "version": "1.0.0",
+            "fields": {
+              "title": "headline"
+            }
+          }
+        ]
+      }
+    },
+    "record.shared-note": {
+      "kind": "record",
+      "value": {
+        "type": "shared_note",
+        "headline": "One record, two consumers"
+      }
+    },
+    "contract.record-changed": {
+      "kind": "contract",
+      "value": {
+        "kind": "mdbase.contract",
+        "contract_type": "event",
+        "id": "example.record.changed",
+        "version": "1.0.0",
+        "name": "Example record changed",
+        "data_schema": {
+          "dialect": "json-schema-2020-12",
+          "value": {
+            "type": "object",
+            "required": ["record_id", "revision"],
+            "additionalProperties": false,
+            "properties": {
+              "record_id": { "type": "string", "minLength": 1 },
+              "revision": { "type": "integer", "minimum": 1 }
+            }
+          }
+        }
+      }
+    },
+    "contract.record-annotate": {
+      "kind": "contract",
+      "value": {
+        "kind": "mdbase.contract",
+        "contract_type": "action",
+        "id": "example.record.annotate",
+        "version": "1.0.0",
+        "name": "Annotate example record",
+        "input_schema": {
+          "dialect": "json-schema-2020-12",
+          "value": {
+            "type": "object",
+            "required": ["record_id", "label"],
+            "additionalProperties": false,
+            "properties": {
+              "record_id": { "type": "string", "minLength": 1 },
+              "label": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "output_schema": {
+          "dialect": "json-schema-2020-12",
+          "value": {
+            "type": "object",
+            "required": ["record_id", "applied"],
+            "additionalProperties": false,
+            "properties": {
+              "record_id": { "type": "string", "minLength": 1 },
+              "applied": { "const": true }
+            }
+          }
+        },
+        "behavior": {
+          "idempotency": "required",
+          "cancellation": "cooperative"
+        }
+      }
+    },
+    "workflow.annotate-changed": {
+      "kind": "workflow",
+      "value": {
+        "type": "runtime_workflow",
+        "id": "example.annotate-changed",
+        "version": "1.0.0",
+        "name": "Annotate changed records",
+        "enabled": true,
+        "triggers": [
+          {
+            "id": "changed",
+            "event": {
+              "id": "example.record.changed",
+              "version": "^1.0.0"
+            }
+          }
+        ],
+        "steps": [
+          {
+            "id": "annotate",
+            "action": {
+              "id": "example.record.annotate",
+              "version": "^1.0.0"
+            },
+            "requires": {
+              "capabilities": ["record.write"]
+            },
+            "input": {
+              "record_id": { "$expr": "event.data.record_id" },
+              "label": "observed"
+            }
+          }
+        ]
+      }
+    },
+    "policy.allow-record-write": {
+      "kind": "policy",
+      "value": {
+        "type": "runtime_policy",
+        "id": "example.testbed-policy",
+        "version": "1.0.0",
+        "enabled": true,
+        "executors": {
+          "default": "testbed-runtime"
+        },
+        "grants": [
+          {
+            "capability": "record.write",
+            "mode": "allow"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/testbed/assets/suite/scenarios/core.shared-contract-consumers.json
+++ b/packages/testbed/assets/suite/scenarios/core.shared-contract-consumers.json
@@ -1,0 +1,88 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "core.shared-contract-consumers",
+  "name": "Two applications consume one type implementation",
+  "description": "One type implements one record contract and two independent consumers observe the same projected contract view.",
+  "ring": "contract",
+  "profile": "core_read",
+  "roles": ["contract_store", "record_consumer"],
+  "operation": "contract.shared-consumers",
+  "fixtures": [
+    "contract.example-note",
+    "type.shared-note",
+    "record.shared-note"
+  ],
+  "parameters": {
+    "consumers": ["consumer-alpha", "consumer-beta"]
+  },
+  "covers": [
+    "core_read.data_contract_discovery",
+    "core_read.data_contract_implementation_validation",
+    "core_read.data_contract_projection"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "contract-store",
+        "operation": "contract.load",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.note",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "arrange",
+        "actor": "contract-store",
+        "operation": "type.load",
+        "outcome": "succeeded",
+        "facts": {
+          "type": "shared_note",
+          "implements": "example.note"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "consumer-alpha",
+        "operation": "contract-view.read",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.note",
+          "view": {
+            "title": "One record, two consumers"
+          }
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "act",
+        "actor": "consumer-beta",
+        "operation": "contract-view.read",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.note",
+          "view": {
+            "title": "One record, two consumers"
+          }
+        }
+      },
+      {
+        "sequence": 5,
+        "phase": "observe",
+        "actor": "testbed",
+        "operation": "contract-view.compare",
+        "outcome": "succeeded",
+        "facts": {
+          "consumers": 2,
+          "same_contract": true,
+          "same_view": true
+        }
+      }
+    ]
+  }
+}

--- a/packages/testbed/assets/suite/scenarios/interop.action-ambiguous.json
+++ b/packages/testbed/assets/suite/scenarios/interop.action-ambiguous.json
@@ -1,0 +1,52 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.action-ambiguous",
+  "name": "Multiple eligible providers are explicitly ambiguous",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["action_caller", "action_provider", "bridge"],
+  "operation": "interop.action-ambiguous",
+  "fixtures": ["contract.record-annotate"],
+  "parameters": {
+    "providers": ["provider-alpha", "provider-beta"]
+  },
+  "covers": [
+    "event_action_interop/0.1.explicit_provider_ambiguity"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "provider-alpha",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.annotate"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "arrange",
+        "actor": "provider-beta",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.annotate"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "rejected",
+        "facts": {
+          "code": "ambiguous_provider",
+          "provider_calls": 0
+        }
+      }
+    ]
+  }
+}

--- a/packages/testbed/assets/suite/scenarios/interop.action-explicit-provider.json
+++ b/packages/testbed/assets/suite/scenarios/interop.action-explicit-provider.json
@@ -1,0 +1,65 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.action-explicit-provider",
+  "name": "An explicit selector resolves provider ambiguity",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["action_caller", "action_provider", "bridge"],
+  "operation": "interop.action-explicit-provider",
+  "fixtures": ["contract.record-annotate"],
+  "parameters": {
+    "providers": ["provider-alpha", "provider-beta"],
+    "selected": "provider-beta"
+  },
+  "covers": [
+    "event_action_interop/0.1.explicit_provider_ambiguity",
+    "event_action_interop/0.1.exact_contract_and_provider_evidence"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "provider-alpha",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.annotate"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "arrange",
+        "actor": "provider-beta",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.annotate"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "succeeded",
+        "facts": {
+          "selected": "provider-beta"
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "observe",
+        "actor": "bridge",
+        "operation": "action.outcome",
+        "outcome": "succeeded",
+        "facts": {
+          "provider": "provider-beta",
+          "provider_alpha_calls": 0,
+          "provider_beta_calls": 1
+        }
+      }
+    ]
+  }
+}

--- a/packages/testbed/assets/suite/scenarios/interop.action-single-provider.json
+++ b/packages/testbed/assets/suite/scenarios/interop.action-single-provider.json
@@ -1,0 +1,57 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.action-single-provider",
+  "name": "A single eligible provider is invoked",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["action_caller", "action_provider", "bridge"],
+  "operation": "interop.action-single-provider",
+  "fixtures": ["contract.record-annotate"],
+  "parameters": {
+    "request_id": "req-single-1",
+    "provider": "provider-alpha"
+  },
+  "covers": [
+    "event_action_interop/0.1.action_request_admission_and_outcome",
+    "event_action_interop/0.1.exact_contract_and_provider_evidence"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "provider-alpha",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.annotate",
+          "idempotency": "request"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "succeeded",
+        "facts": {
+          "request_id": "req-single-1"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "observe",
+        "actor": "bridge",
+        "operation": "action.outcome",
+        "outcome": "succeeded",
+        "facts": {
+          "exact_contract": true,
+          "provider": "provider-alpha",
+          "provider_calls": 1,
+          "request_id": "req-single-1"
+        }
+      }
+    ]
+  }
+}

--- a/packages/testbed/assets/suite/scenarios/interop.application-event-multicast.json
+++ b/packages/testbed/assets/suite/scenarios/interop.application-event-multicast.json
@@ -1,0 +1,75 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.application-event-multicast",
+  "name": "An application event source reaches two independent consumers",
+  "description": "A real application-owned event contract is multicast without making its product-specific payload part of the neutral oracle.",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["event_source", "event_consumer", "bridge"],
+  "operation": "interop.application-event-multicast",
+  "fixtures": [],
+  "parameters": {},
+  "covers": [
+    "event_action_interop/0.1.cloudevents_event_envelope",
+    "event_action_interop/0.1.event_multicast_and_version_resolution",
+    "event_action_interop/0.1.boundary_validation"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "application",
+        "operation": "contract.describe",
+        "outcome": "succeeded",
+        "facts": {
+          "contract_type": "event",
+          "schema": "json-schema-2020-12"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "arrange",
+        "actor": "application",
+        "operation": "event-source.register",
+        "outcome": "succeeded",
+        "facts": {
+          "sources": 1
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "arrange",
+        "actor": "consumers",
+        "operation": "event.subscribe",
+        "outcome": "succeeded",
+        "facts": {
+          "consumers": 2
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "act",
+        "actor": "application",
+        "operation": "event.publish",
+        "outcome": "succeeded",
+        "facts": {
+          "exact_contract": true,
+          "specversion": "1.0"
+        }
+      },
+      {
+        "sequence": 5,
+        "phase": "observe",
+        "actor": "bridge",
+        "operation": "event.deliver",
+        "outcome": "succeeded",
+        "facts": {
+          "deliveries": 2,
+          "distinct_consumers": 2
+        }
+      }
+    ]
+  }
+}

--- a/packages/testbed/assets/suite/scenarios/interop.application-provider-lifecycle.json
+++ b/packages/testbed/assets/suite/scenarios/interop.application-provider-lifecycle.json
@@ -1,0 +1,84 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.application-provider-lifecycle",
+  "name": "An application provider validates, invokes, and unloads cleanly",
+  "description": "A real application-owned action contract is exercised without making its product-specific contract part of the neutral oracle.",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["action_caller", "action_provider", "bridge"],
+  "operation": "interop.application-provider-lifecycle",
+  "fixtures": [],
+  "parameters": {},
+  "covers": [
+    "event_action_interop/0.1.action_request_admission_and_outcome",
+    "event_action_interop/0.1.boundary_validation",
+    "event_action_interop/0.1.cancellation_and_unload"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "application",
+        "operation": "contract.describe",
+        "outcome": "succeeded",
+        "facts": {
+          "contract_type": "action",
+          "schema": "json-schema-2020-12"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "arrange",
+        "actor": "application",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "providers": 1
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "succeeded",
+        "facts": {
+          "exact_contract": true,
+          "provider_calls": 1
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "act",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "rejected",
+        "facts": {
+          "code": "invalid_action_input"
+        }
+      },
+      {
+        "sequence": 5,
+        "phase": "act",
+        "actor": "application",
+        "operation": "client.dispose",
+        "outcome": "succeeded",
+        "facts": {
+          "providers": 0
+        }
+      },
+      {
+        "sequence": 6,
+        "phase": "observe",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "rejected",
+        "facts": {
+          "code": "no_provider"
+        }
+      }
+    ]
+  }
+}

--- a/packages/testbed/assets/suite/scenarios/interop.authority-boundary.json
+++ b/packages/testbed/assets/suite/scenarios/interop.authority-boundary.json
@@ -1,0 +1,51 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.authority-boundary",
+  "name": "Contract compatibility never grants provider authority",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["action_provider", "bridge"],
+  "operation": "interop.authority-boundary",
+  "fixtures": ["contract.record-annotate"],
+  "parameters": {
+    "denied_application": "untrusted-provider"
+  },
+  "covers": [
+    "event_action_interop/0.1.independent_authorization"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "untrusted-provider",
+        "operation": "contract.validate",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.annotate"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "untrusted-provider",
+        "operation": "action-provider.register",
+        "outcome": "rejected",
+        "facts": {
+          "code": "unauthorized"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "observe",
+        "actor": "bridge",
+        "operation": "registry.inspect",
+        "outcome": "succeeded",
+        "facts": {
+          "providers": 0
+        }
+      }
+    ]
+  }
+}

--- a/packages/testbed/assets/suite/scenarios/interop.contract-digest-drift.json
+++ b/packages/testbed/assets/suite/scenarios/interop.contract-digest-drift.json
@@ -1,0 +1,53 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.contract-digest-drift",
+  "name": "Digest drift for one exact contract identity fails atomically",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["event_source", "bridge"],
+  "operation": "interop.contract-digest-drift",
+  "fixtures": ["contract.record-changed"],
+  "parameters": {
+    "mutate": "data_schema.value.properties.record_id.minLength"
+  },
+  "covers": [
+    "event_action_interop/0.1.first_class_event_and_action_contracts",
+    "event_action_interop/0.1.boundary_validation"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "source-alpha",
+        "operation": "event-source.register",
+        "outcome": "succeeded",
+        "facts": {
+          "sources": 1
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "source-beta",
+        "operation": "event-source.register",
+        "outcome": "rejected",
+        "facts": {
+          "code": "contract_digest_conflict"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "observe",
+        "actor": "bridge",
+        "operation": "registry.inspect",
+        "outcome": "succeeded",
+        "facts": {
+          "atomic": true,
+          "sources": 1
+        }
+      }
+    ]
+  }
+}

--- a/packages/testbed/assets/suite/scenarios/interop.event-multicast.json
+++ b/packages/testbed/assets/suite/scenarios/interop.event-multicast.json
@@ -1,0 +1,78 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.event-multicast",
+  "name": "One event is multicast to every compatible consumer",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["event_source", "event_consumer", "bridge"],
+  "operation": "interop.event-multicast",
+  "fixtures": ["contract.record-changed"],
+  "parameters": {
+    "event_id": "evt-shared-1",
+    "consumers": ["consumer-alpha", "consumer-beta"]
+  },
+  "covers": [
+    "event_action_interop/0.1.cloudevents_event_envelope",
+    "event_action_interop/0.1.event_multicast_and_version_resolution"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "source",
+        "operation": "event-source.register",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.changed",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "arrange",
+        "actor": "consumer-alpha",
+        "operation": "event.subscribe",
+        "outcome": "succeeded",
+        "facts": {
+          "version": "^1.0.0"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "arrange",
+        "actor": "consumer-beta",
+        "operation": "event.subscribe",
+        "outcome": "succeeded",
+        "facts": {
+          "version": ">=1.0.0 <2.0.0"
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "act",
+        "actor": "source",
+        "operation": "event.publish",
+        "outcome": "succeeded",
+        "facts": {
+          "event_id": "evt-shared-1"
+        }
+      },
+      {
+        "sequence": 5,
+        "phase": "observe",
+        "actor": "bridge",
+        "operation": "event.deliver",
+        "outcome": "succeeded",
+        "facts": {
+          "consumers": ["consumer-alpha", "consumer-beta"],
+          "deliveries": 2,
+          "duplicate": false,
+          "exact_contract": true,
+          "specversion": "1.0"
+        }
+      }
+    ]
+  }
+}

--- a/packages/testbed/assets/suite/scenarios/interop.invalid-payload.json
+++ b/packages/testbed/assets/suite/scenarios/interop.invalid-payload.json
@@ -1,0 +1,63 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.invalid-payload",
+  "name": "Invalid event data is rejected before delivery",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["event_source", "event_consumer", "bridge"],
+  "operation": "interop.invalid-payload",
+  "fixtures": ["contract.record-changed"],
+  "parameters": {
+    "data": {
+      "record_id": "note-1"
+    }
+  },
+  "covers": [
+    "event_action_interop/0.1.boundary_validation"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "source",
+        "operation": "event-source.register",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.changed"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "arrange",
+        "actor": "consumer",
+        "operation": "event.subscribe",
+        "outcome": "succeeded",
+        "facts": {
+          "version": "^1.0.0"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "source",
+        "operation": "event.publish",
+        "outcome": "rejected",
+        "facts": {
+          "code": "invalid_event_data"
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "observe",
+        "actor": "consumer",
+        "operation": "event.deliver",
+        "outcome": "skipped",
+        "facts": {
+          "deliveries": 0
+        }
+      }
+    ]
+  }
+}

--- a/packages/testbed/assets/suite/scenarios/interop.provider-disappearance.json
+++ b/packages/testbed/assets/suite/scenarios/interop.provider-disappearance.json
@@ -1,0 +1,52 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.provider-disappearance",
+  "name": "Unloading a provider removes it from admission",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["action_caller", "action_provider", "bridge"],
+  "operation": "interop.provider-disappearance",
+  "fixtures": ["contract.record-annotate"],
+  "parameters": {
+    "provider": "provider-alpha"
+  },
+  "covers": [
+    "event_action_interop/0.1.cancellation_and_unload"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "provider-alpha",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "providers": 1
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "provider-alpha",
+        "operation": "client.dispose",
+        "outcome": "succeeded",
+        "facts": {
+          "providers": 0
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "observe",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "rejected",
+        "facts": {
+          "code": "no_provider",
+          "provider_calls": 0
+        }
+      }
+    ]
+  }
+}

--- a/packages/testbed/assets/suite/scenarios/interop.request-replay.json
+++ b/packages/testbed/assets/suite/scenarios/interop.request-replay.json
@@ -1,0 +1,63 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.request-replay",
+  "name": "A declared idempotent request reuses its recorded outcome",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["action_caller", "action_provider", "bridge"],
+  "operation": "interop.request-replay",
+  "fixtures": ["contract.record-annotate"],
+  "parameters": {
+    "request_id": "req-replay-1",
+    "idempotency_key": "run-1:annotate"
+  },
+  "covers": [
+    "event_action_interop/0.1.duplicate_and_indeterminate_semantics"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "provider-alpha",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "idempotency": "request"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "succeeded",
+        "facts": {
+          "request_id": "req-replay-1"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "caller",
+        "operation": "action.replay",
+        "outcome": "succeeded",
+        "facts": {
+          "request_id": "req-replay-1"
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "observe",
+        "actor": "bridge",
+        "operation": "action.outcome",
+        "outcome": "succeeded",
+        "facts": {
+          "handler_calls": 1,
+          "same_outcome": true
+        }
+      }
+    ]
+  }
+}

--- a/packages/testbed/assets/suite/scenarios/runtime.application-execution.json
+++ b/packages/testbed/assets/suite/scenarios/runtime.application-execution.json
@@ -1,0 +1,75 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "runtime.application-execution",
+  "name": "An application-owned runtime executes one exact admitted effect",
+  "description": "A product runtime composes its real contracts, admits an exact source/provider plan, authorizes dispatch, and persists one successful run.",
+  "ring": "runtime",
+  "profile": "runtime/0.2",
+  "roles": ["event_source", "action_provider", "runtime", "runtime_store"],
+  "operation": "runtime.application-execution",
+  "fixtures": [],
+  "parameters": {},
+  "covers": [
+    "runtime/0.2.exact_contract_source_and_provider_admission",
+    "runtime/0.2.dispatch_authorization",
+    "runtime/0.2.durable_event_admission"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "application-runtime",
+        "operation": "catalog.compose",
+        "outcome": "succeeded",
+        "facts": {
+          "contracts_verified": true,
+          "executor_selected": true
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "event-source",
+        "operation": "event.publish",
+        "outcome": "succeeded",
+        "facts": {
+          "exact_contract": true
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "application-runtime",
+        "operation": "event.admit",
+        "outcome": "succeeded",
+        "facts": {
+          "runs": 1
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "act",
+        "actor": "action-provider",
+        "operation": "action.dispatch",
+        "outcome": "succeeded",
+        "facts": {
+          "authorization_checked": true,
+          "provider_calls": 1
+        }
+      },
+      {
+        "sequence": 5,
+        "phase": "observe",
+        "actor": "runtime-store",
+        "operation": "run.inspect",
+        "outcome": "succeeded",
+        "facts": {
+          "exact_bindings": true,
+          "status": "succeeded"
+        }
+      }
+    ]
+  }
+}

--- a/packages/testbed/assets/suite/scenarios/runtime.competing-workers.json
+++ b/packages/testbed/assets/suite/scenarios/runtime.competing-workers.json
@@ -1,0 +1,82 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "runtime.competing-workers",
+  "name": "Competing workers are fenced by one durable lease",
+  "ring": "runtime",
+  "profile": "runtime/0.2",
+  "roles": ["runtime", "runtime_store"],
+  "operation": "runtime.competing-workers",
+  "fixtures": [
+    "contract.record-changed",
+    "contract.record-annotate",
+    "workflow.annotate-changed",
+    "policy.allow-record-write"
+  ],
+  "parameters": {
+    "event_id": "evt-fence-1",
+    "workers": ["worker-alpha", "worker-beta"]
+  },
+  "covers": [
+    "runtime/0.2.idempotency_and_concurrency",
+    "runtime/0.2.lease_and_crash_recovery",
+    "runtime/0.2.run_state_machine"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "runtime",
+        "operation": "event.admit",
+        "outcome": "succeeded",
+        "facts": {
+          "event_id": "evt-fence-1",
+          "runs": 1
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "worker-alpha",
+        "operation": "run.claim",
+        "outcome": "succeeded",
+        "facts": {
+          "claims": 1
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "worker-beta",
+        "operation": "run.claim",
+        "outcome": "skipped",
+        "facts": {
+          "claims": 0
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "recover",
+        "actor": "worker-alpha",
+        "operation": "run.commit",
+        "outcome": "rejected",
+        "facts": {
+          "code": "stale_lease"
+        }
+      },
+      {
+        "sequence": 5,
+        "phase": "observe",
+        "actor": "runtime-store",
+        "operation": "run.inspect",
+        "outcome": "succeeded",
+        "facts": {
+          "concurrent_claims": 1,
+          "runs": 1,
+          "winner": "worker-beta"
+        }
+      }
+    ]
+  }
+}

--- a/packages/testbed/assets/suite/scenarios/runtime.crash-recovery.json
+++ b/packages/testbed/assets/suite/scenarios/runtime.crash-recovery.json
@@ -1,0 +1,73 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "runtime.crash-recovery",
+  "name": "An unknown idempotent dispatch recovers without a duplicate effect",
+  "ring": "runtime",
+  "profile": "runtime/0.2",
+  "roles": ["runtime", "runtime_store", "action_provider"],
+  "operation": "runtime.crash-recovery",
+  "fixtures": [
+    "contract.record-changed",
+    "contract.record-annotate",
+    "workflow.annotate-changed",
+    "policy.allow-record-write"
+  ],
+  "parameters": {
+    "event_id": "evt-crash-1",
+    "failpoint": "after_provider_effect_before_result_commit",
+    "expire_lease": true
+  },
+  "covers": [
+    "runtime/0.2.durable_action_attempts",
+    "runtime/0.2.lease_and_crash_recovery"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "runtime",
+        "operation": "event.admit",
+        "outcome": "succeeded",
+        "facts": {
+          "event_id": "evt-crash-1",
+          "runs": 1
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "worker-alpha",
+        "operation": "action.dispatch",
+        "outcome": "indeterminate",
+        "facts": {
+          "provider_effects": 1
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "recover",
+        "actor": "worker-beta",
+        "operation": "lease.recover",
+        "outcome": "succeeded",
+        "facts": {
+          "same_attempt_id": true,
+          "same_invocation_id": true
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "observe",
+        "actor": "runtime-store",
+        "operation": "run.inspect",
+        "outcome": "succeeded",
+        "facts": {
+          "dispatches": 2,
+          "logical_effects": 1,
+          "status": "succeeded"
+        }
+      }
+    ]
+  }
+}

--- a/packages/testbed/package-lock.json
+++ b/packages/testbed/package-lock.json
@@ -1,0 +1,151 @@
+{
+  "name": "@callumalpass/mdbase-testbed",
+  "version": "0.1.0-rc.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@callumalpass/mdbase-testbed",
+      "version": "0.1.0-rc.1",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1"
+      },
+      "bin": {
+        "mdbase-testbed": "src/cli.mjs",
+        "mdbase-testbed-reference": "dist/reference.mjs"
+      },
+      "devDependencies": {
+        "esbuild": "^0.25.9",
+        "semver": "^7.8.5"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  }
+}

--- a/packages/testbed/package.json
+++ b/packages/testbed/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@callumalpass/mdbase-testbed",
+  "version": "0.1.0-rc.1",
+  "type": "module",
+  "description": "Black-box conformance runner and neutral scenarios for mdbase contracts, interoperability, and durable runtimes.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mdbase-dev/mdbase-spec.git",
+    "directory": "packages/testbed"
+  },
+  "bugs": {
+    "url": "https://github.com/mdbase-dev/mdbase-spec/issues"
+  },
+  "homepage": "https://mdbase.dev/testbed/",
+  "exports": {
+    ".": "./src/index.mjs"
+  },
+  "bin": {
+    "mdbase-testbed": "./src/cli.mjs",
+    "mdbase-testbed-reference": "./dist/reference.mjs"
+  },
+  "files": [
+    "assets",
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build:reference": "esbuild adapters/reference.mjs --bundle --platform=node --format=esm --target=node20 --outfile=dist/reference.mjs",
+    "prepack": "npm run build:reference && npm run sync:assets",
+    "sync:assets": "node scripts/sync-assets.mjs",
+    "test": "npm run build:reference && npm run sync:assets && node --test test/*.test.mjs",
+    "test:reference": "npm run sync:assets && node src/cli.mjs run --adapter reference"
+  },
+  "dependencies": {
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1"
+  },
+  "devDependencies": {
+    "esbuild": "^0.25.9",
+    "semver": "^7.8.5"
+  }
+}

--- a/packages/testbed/scripts/sync-assets.mjs
+++ b/packages/testbed/scripts/sync-assets.mjs
@@ -1,0 +1,20 @@
+import { cpSync, mkdirSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = resolve(packageRoot, "../..");
+const destination = join(packageRoot, "assets");
+
+rmSync(destination, { recursive: true, force: true });
+mkdirSync(destination, { recursive: true });
+cpSync(
+  join(repositoryRoot, "schemas/testbed/v0.1"),
+  join(destination, "schemas"),
+  { recursive: true }
+);
+cpSync(
+  join(repositoryRoot, "testbed/v0.1"),
+  join(destination, "suite"),
+  { recursive: true }
+);

--- a/packages/testbed/src/cli.mjs
+++ b/packages/testbed/src/cli.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+import { writeFileSync } from "node:fs";
+import {
+  loadTestbed,
+  runTestbed,
+  validateTestbed
+} from "./index.mjs";
+
+const [command = "help", ...args] = process.argv.slice(2);
+
+try {
+  if (command === "list") {
+    const { scenarios } = loadTestbed();
+    for (const scenario of scenarios) {
+      process.stdout.write(
+        `${scenario.id}\t${scenario.ring}\t${scenario.profile}\t${scenario.name}\n`
+      );
+    }
+  } else if (command === "validate") {
+    const summary = validateTestbed();
+    process.stdout.write(
+      `Testbed 0.1 valid: ${summary.fixtures} fixtures, `
+      + `${summary.scenarios} scenarios, ${summary.profiles.length} profiles.\n`
+    );
+  } else if (command === "run") {
+    const options = parseRunArgs(args);
+    const run = await runTestbed(options);
+    for (const result of run.results) {
+      process.stdout.write(`${result.pass ? "PASS" : "FAIL"} ${result.id}\n`);
+      if (!result.pass) {
+        process.stderr.write(
+          `${result.id}: observable transcript did not match the canonical transcript.\n`
+          + `  first difference at ${result.mismatch.path}\n`
+          + `  expected: ${JSON.stringify(result.mismatch.expected)}\n`
+          + `  received: ${JSON.stringify(result.mismatch.actual)}\n`
+        );
+      }
+    }
+    if (options.evidence) {
+      writeFileSync(options.evidence, `${JSON.stringify(run.evidence, null, 2)}\n`, "utf8");
+      process.stdout.write(`Evidence: ${options.evidence}\n`);
+    }
+    if (!run.results.every(({ pass }) => pass)) process.exitCode = 1;
+  } else {
+    process.stdout.write(`mdbase-testbed 0.1
+
+Usage:
+  mdbase-testbed validate
+  mdbase-testbed list
+  mdbase-testbed run [--adapter reference|PATH] [--adapter-arg VALUE]
+                     [--scenario ID] [--profile PROFILE]
+                     [--evidence PATH] [--timeout-ms NUMBER]
+
+Use --adapter command:NAME with repeated --adapter-arg options when an adapter
+is launched through a command such as cargo.
+`);
+  }
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}
+
+function parseRunArgs(values) {
+  const options = {
+    adapter: "reference",
+    adapterArgs: [],
+    scenarios: []
+  };
+  for (let index = 0; index < values.length; index += 1) {
+    const flag = values[index];
+    const value = values[index + 1];
+    if (
+      ![
+        "--adapter",
+        "--adapter-arg",
+        "--scenario",
+        "--profile",
+        "--evidence",
+        "--timeout-ms"
+      ].includes(flag)
+    ) {
+      throw new Error(`Unknown option: ${flag}`);
+    }
+    if (value === undefined) throw new Error(`${flag} requires a value.`);
+    index += 1;
+    if (flag === "--adapter") options.adapter = value;
+    if (flag === "--adapter-arg") options.adapterArgs.push(value);
+    if (flag === "--scenario") options.scenarios.push(value);
+    if (flag === "--profile") options.profile = value;
+    if (flag === "--evidence") options.evidence = value;
+    if (flag === "--timeout-ms") {
+      options.timeoutMs = Number(value);
+      if (!Number.isInteger(options.timeoutMs) || options.timeoutMs < 1) {
+        throw new Error("--timeout-ms must be a positive integer.");
+      }
+    }
+  }
+  return options;
+}

--- a/packages/testbed/src/index.mjs
+++ b/packages/testbed/src/index.mjs
@@ -1,0 +1,372 @@
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import {
+  readFileSync,
+  readdirSync
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { fileURLToPath } from "node:url";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+
+export const TESTBED_PROTOCOL_VERSION = "0.1";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const assetsRoot = join(packageRoot, "assets");
+const schemasRoot = join(assetsRoot, "schemas");
+const suiteRoot = join(assetsRoot, "suite");
+
+export function loadTestbed() {
+  const catalog = readJson(join(suiteRoot, "fixtures/catalog.json"));
+  const scenarios = readdirSync(join(suiteRoot, "scenarios"))
+    .filter((name) => name.endsWith(".json"))
+    .sort()
+    .map((name) => readJson(join(suiteRoot, "scenarios", name)));
+  return { catalog, scenarios };
+}
+
+export function validateTestbed() {
+  const validators = createValidators();
+  const { catalog, scenarios } = loadTestbed();
+  assertValid(validators.fixtureCatalog, catalog, "fixture catalog");
+  const knownFixtures = new Set(Object.keys(catalog.fixtures));
+  const knownScenarios = new Set();
+
+  for (const scenario of scenarios) {
+    assertValid(validators.scenario, scenario, `scenario ${scenario.id ?? "<unknown>"}`);
+    if (knownScenarios.has(scenario.id)) {
+      throw new Error(`Duplicate testbed scenario ID: ${scenario.id}`);
+    }
+    knownScenarios.add(scenario.id);
+    for (const fixture of scenario.fixtures) {
+      if (!knownFixtures.has(fixture)) {
+        throw new Error(`Scenario ${scenario.id} references unknown fixture ${fixture}.`);
+      }
+    }
+    assertSequential(scenario);
+    assertValid(
+      validators.transcript,
+      {
+        kind: "mdbase.testbed.transcript",
+        protocol_version: TESTBED_PROTOCOL_VERSION,
+        scenario_id: scenario.id,
+        implementation: {
+          id: "testbed.oracle",
+          name: "Canonical expected transcript",
+          version: TESTBED_PROTOCOL_VERSION
+        },
+        entries: scenario.expect.entries
+      },
+      `expected transcript ${scenario.id}`
+    );
+  }
+  return {
+    fixtures: knownFixtures.size,
+    scenarios: scenarios.length,
+    profiles: [...new Set(scenarios.map(({ profile }) => profile))].sort()
+  };
+}
+
+export async function describeAdapter(adapter, options = {}) {
+  const target = resolveAdapter(adapter, options.adapterArgs ?? []);
+  const result = await invoke(target, ["describe"], undefined, options.timeoutMs);
+  const description = parseAdapterJson(result.stdout, "adapter description");
+  assertValid(createValidators().adapterDescription, description, "adapter description");
+  return description;
+}
+
+export async function runTestbed(options = {}) {
+  validateTestbed();
+  const validators = createValidators();
+  const { catalog, scenarios } = loadTestbed();
+  const target = resolveAdapter(options.adapter ?? "reference", options.adapterArgs ?? []);
+  const description = await describeAdapter(options.adapter ?? "reference", options);
+  const selected = selectScenarios(scenarios, description, options);
+  const results = [];
+
+  for (const scenario of selected) {
+    const fixtures = Object.fromEntries(
+      scenario.fixtures.map((id) => [id, structuredClone(catalog.fixtures[id])])
+    );
+    const request = {
+      kind: "mdbase.testbed.run",
+      protocol_version: TESTBED_PROTOCOL_VERSION,
+      scenario,
+      fixtures
+    };
+    assertValid(validators.runRequest, request, `run request ${scenario.id}`);
+    const processResult = await invoke(
+      target,
+      ["run"],
+      `${JSON.stringify(request)}\n`,
+      options.timeoutMs
+    );
+    const transcript = parseAdapterJson(
+      processResult.stdout,
+      `transcript for ${scenario.id}`
+    );
+    assertValid(validators.transcript, transcript, `transcript ${scenario.id}`);
+    if (transcript.scenario_id !== scenario.id) {
+      throw new Error(
+        `Adapter returned scenario ${transcript.scenario_id} while running ${scenario.id}.`
+      );
+    }
+    if (!isDeepStrictEqual(transcript.implementation, description.implementation)) {
+      throw new Error(
+        `Transcript implementation does not match the adapter description for ${scenario.id}.`
+      );
+    }
+    const pass = isDeepStrictEqual(transcript.entries, scenario.expect.entries);
+    const mismatch = pass
+      ? undefined
+      : firstDifference(scenario.expect.entries, transcript.entries, "entries");
+    results.push({
+      id: scenario.id,
+      profile: scenario.profile,
+      pass,
+      ...(mismatch ? { mismatch } : {}),
+      transcript,
+      transcript_digest: portableDigest(transcript)
+    });
+  }
+
+  return {
+    description,
+    results,
+    evidence: evidenceFor(description.implementation, results)
+  };
+}
+
+export function portableDigest(value) {
+  return `sha256:${createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+export function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) =>
+    `${JSON.stringify(key)}:${canonicalJson(value[key])}`
+  ).join(",")}}`;
+}
+
+export function firstDifference(expected, actual, path = "$") {
+  if (isDeepStrictEqual(expected, actual)) return undefined;
+  if (Array.isArray(expected) && Array.isArray(actual)) {
+    const length = Math.max(expected.length, actual.length);
+    for (let index = 0; index < length; index += 1) {
+      if (index >= expected.length) {
+        return {
+          path: `${path}[${index}]`,
+          expected: "<absent>",
+          actual: actual[index]
+        };
+      }
+      if (index >= actual.length) {
+        return {
+          path: `${path}[${index}]`,
+          expected: expected[index],
+          actual: "<absent>"
+        };
+      }
+      const difference = firstDifference(
+        expected[index],
+        actual[index],
+        `${path}[${index}]`
+      );
+      if (difference) return difference;
+    }
+  }
+  if (isPlainObject(expected) && isPlainObject(actual)) {
+    for (const key of [...new Set([
+      ...Object.keys(expected),
+      ...Object.keys(actual)
+    ])].sort()) {
+      if (!(key in expected)) {
+        return {
+          path: `${path}.${key}`,
+          expected: "<absent>",
+          actual: actual[key]
+        };
+      }
+      if (!(key in actual)) {
+        return {
+          path: `${path}.${key}`,
+          expected: expected[key],
+          actual: "<absent>"
+        };
+      }
+      const difference = firstDifference(
+        expected[key],
+        actual[key],
+        `${path}.${key}`
+      );
+      if (difference) return difference;
+    }
+  }
+  return { path, expected, actual };
+}
+
+function createValidators() {
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  addFormats(ajv);
+  const schemas = Object.fromEntries(
+    readdirSync(schemasRoot)
+      .filter((name) => name.endsWith(".schema.json"))
+      .sort()
+      .map((name) => [name, readJson(join(schemasRoot, name))])
+  );
+  for (const schema of Object.values(schemas)) ajv.addSchema(schema);
+  return {
+    adapterDescription: ajv.getSchema(schemas["adapter-description.schema.json"].$id),
+    evidence: ajv.getSchema(schemas["evidence.schema.json"].$id),
+    fixtureCatalog: ajv.getSchema(schemas["fixture-catalog.schema.json"].$id),
+    runRequest: ajv.getSchema(schemas["run-request.schema.json"].$id),
+    scenario: ajv.getSchema(schemas["scenario.schema.json"].$id),
+    transcript: ajv.getSchema(schemas["transcript.schema.json"].$id)
+  };
+}
+
+function selectScenarios(scenarios, description, options) {
+  const requestedIds = new Set(options.scenarios ?? []);
+  const supported = new Set(description.scenarios);
+  const profile = options.profile;
+  let selected = scenarios.filter((scenario) =>
+    (requestedIds.size === 0 || requestedIds.has(scenario.id))
+    && (profile === undefined || scenario.profile === profile)
+  );
+  if (requestedIds.size > 0) {
+    const unknown = [...requestedIds].filter(
+      (id) => !scenarios.some((scenario) => scenario.id === id)
+    );
+    if (unknown.length > 0) {
+      throw new Error(`Unknown testbed scenario(s): ${unknown.join(", ")}`);
+    }
+  }
+  if (profile !== undefined || requestedIds.size > 0) {
+    const missing = selected.filter((scenario) => !supported.has(scenario.id));
+    if (missing.length > 0) {
+      throw new Error(
+        `Adapter ${description.implementation.id} does not support requested scenario(s): `
+        + missing.map(({ id }) => id).join(", ")
+      );
+    }
+  } else {
+    selected = selected.filter((scenario) => supported.has(scenario.id));
+  }
+  if (selected.length === 0) {
+    throw new Error(`Adapter ${description.implementation.id} has no selected scenarios.`);
+  }
+  return selected;
+}
+
+function evidenceFor(implementation, results) {
+  const evidence = {
+    kind: "mdbase.testbed.evidence",
+    protocol_version: TESTBED_PROTOCOL_VERSION,
+    implementation,
+    result: results.every(({ pass }) => pass) ? "pass" : "fail",
+    scenarios: results.map((result) => ({
+      id: result.id,
+      profile: result.profile,
+      result: result.pass ? "pass" : "fail",
+      transcript_digest: result.transcript_digest
+    }))
+  };
+  assertValid(createValidators().evidence, evidence, "testbed evidence");
+  return evidence;
+}
+
+function resolveAdapter(adapter, adapterArgs) {
+  if (adapter === "reference") {
+    return {
+      command: process.execPath,
+      args: [join(packageRoot, "dist/reference.mjs")]
+    };
+  }
+  if (adapter.startsWith("command:")) {
+    const command = adapter.slice("command:".length);
+    if (command.length === 0) {
+      throw new Error("A command: adapter must name an executable.");
+    }
+    return { command, args: adapterArgs };
+  }
+  const resolved = resolve(adapter);
+  if (/\.(?:cjs|mjs|js)$/u.test(resolved)) {
+    return { command: process.execPath, args: [resolved, ...adapterArgs] };
+  }
+  return { command: resolved, args: adapterArgs };
+}
+
+function invoke(target, args, input, timeoutMs = 30_000) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(target.command, [...target.args, ...args], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        MDBASE_TESTBED_PROTOCOL_VERSION: TESTBED_PROTOCOL_VERSION
+      }
+    });
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      rejectPromise(new Error(
+        `Adapter timed out after ${timeoutMs}ms: ${target.command} ${args.join(" ")}`
+      ));
+    }, timeoutMs);
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      rejectPromise(error);
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timeout);
+      if (code !== 0) {
+        rejectPromise(new Error(
+          `Adapter exited with ${code ?? signal}: ${stderr.trim() || "<no diagnostic>"}`
+        ));
+        return;
+      }
+      resolvePromise({ stdout, stderr });
+    });
+    child.stdin.end(input);
+  });
+}
+
+function parseAdapterJson(source, label) {
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    throw new Error(`Invalid ${label} JSON: ${error.message}`);
+  }
+}
+
+function assertValid(validator, value, label) {
+  if (validator(value)) return;
+  const errors = (validator.errors ?? [])
+    .map(({ instancePath, message }) => `${instancePath || "/"} ${message}`)
+    .join("; ");
+  throw new Error(`Invalid ${label}: ${errors}`);
+}
+
+function assertSequential(scenario) {
+  scenario.expect.entries.forEach((entry, index) => {
+    if (entry.sequence !== index + 1) {
+      throw new Error(
+        `Scenario ${scenario.id} transcript sequence must be ${index + 1}, got ${entry.sequence}.`
+      );
+    }
+  });
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/testbed/test/testbed.test.mjs
+++ b/packages/testbed/test/testbed.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  canonicalJson,
+  describeAdapter,
+  firstDifference,
+  loadTestbed,
+  portableDigest,
+  runTestbed,
+  validateTestbed
+} from "../src/index.mjs";
+
+test("validates the complete neutral scenario inventory", () => {
+  const result = validateTestbed();
+  assert.deepEqual(result, {
+    fixtures: 7,
+    scenarios: 15,
+    profiles: [
+      "core_read",
+      "event_action_interop/0.1",
+      "runtime/0.2"
+    ]
+  });
+});
+
+test("keeps scenarios product-neutral and expected transcripts sequential", () => {
+  const { scenarios } = loadTestbed();
+  const encoded = JSON.stringify(scenarios);
+  for (const productName of [
+    "tasknotes",
+    "canvas-bases",
+    "workflows",
+    "pickle",
+    "connect"
+  ]) {
+    assert.equal(encoded.includes(productName), false, productName);
+  }
+  for (const scenario of scenarios) {
+    assert.deepEqual(
+      scenario.expect.entries.map(({ sequence }) => sequence),
+      scenario.expect.entries.map((_, index) => index + 1)
+    );
+  }
+});
+
+test("describes and runs the black-box reference adapter", async () => {
+  const description = await describeAdapter("reference");
+  assert.equal(description.kind, "mdbase.testbed.adapter");
+  assert.equal(description.scenarios.length, 9);
+
+  const run = await runTestbed({ adapter: "reference" });
+  assert.equal(run.results.length, 9);
+  assert.equal(run.results.every(({ pass }) => pass), true);
+  assert.equal(run.evidence.result, "pass");
+});
+
+test("can select one scenario and rejects an unsupported requested ring", async () => {
+  const selected = await runTestbed({
+    adapter: "reference",
+    scenarios: ["interop.event-multicast"]
+  });
+  assert.deepEqual(selected.results.map(({ id }) => id), [
+    "interop.event-multicast"
+  ]);
+
+  await assert.rejects(
+    runTestbed({
+      adapter: "reference",
+      scenarios: ["runtime.crash-recovery"]
+    }),
+    /does not support requested scenario/
+  );
+});
+
+test("portable transcript digests use recursively sorted JSON object keys", () => {
+  assert.equal(canonicalJson({ z: 1, a: { y: 2, b: 3 } }), '{"a":{"b":3,"y":2},"z":1}');
+  assert.equal(
+    portableDigest({ b: 2, a: 1 }),
+    portableDigest({ a: 1, b: 2 })
+  );
+  assert.match(portableDigest({ stable: true }), /^sha256:[0-9a-f]{64}$/u);
+});
+
+test("reports the first stable transcript difference", () => {
+  assert.deepEqual(
+    firstDifference(
+      [{ facts: { calls: 1, exact: true } }],
+      [{ facts: { calls: 2, exact: true } }],
+      "entries"
+    ),
+    {
+      path: "entries[0].facts.calls",
+      expected: 1,
+      actual: 2
+    }
+  );
+});

--- a/schemas/testbed/v0.1/README.md
+++ b/schemas/testbed/v0.1/README.md
@@ -1,0 +1,15 @@
+# mdbase interoperability testbed schemas
+
+These Draft 2020-12 schemas define portable testbed protocol `0.1`:
+
+- `scenario.schema.json` validates neutral, spec-owned scenario definitions.
+- `fixture-catalog.schema.json` validates the shared input catalog.
+- `adapter-description.schema.json` validates the capabilities reported by a
+  black-box adapter.
+- `run-request.schema.json` validates the complete input sent to an adapter.
+- `transcript.schema.json` validates deterministic observable results.
+- `evidence.schema.json` validates the digest-bound run summary suitable for a
+  conformance claim.
+
+The process protocol and conformance rules are defined in
+[`testbed/v0.1/README.md`](../../../testbed/v0.1/README.md).

--- a/schemas/testbed/v0.1/adapter-description.schema.json
+++ b/schemas/testbed/v0.1/adapter-description.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/testbed/v0.1/adapter-description.schema.json",
+  "title": "mdbase interoperability testbed adapter description",
+  "type": "object",
+  "required": [
+    "kind",
+    "protocol_version",
+    "implementation",
+    "profiles",
+    "roles",
+    "scenarios"
+  ],
+  "properties": {
+    "kind": { "const": "mdbase.testbed.adapter" },
+    "protocol_version": { "const": "0.1" },
+    "implementation": {
+      "type": "object",
+      "required": ["id", "name", "version"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[A-Za-z][A-Za-z0-9._:/-]*$"
+        },
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "language": { "type": "string", "minLength": 1 },
+        "target": { "type": "string", "minLength": 1 }
+      },
+      "patternProperties": {
+        "^x-[A-Za-z0-9._:-]+$": true
+      },
+      "additionalProperties": false
+    },
+    "profiles": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "core_read",
+          "event_action_interop/0.1",
+          "runtime/0.2"
+        ]
+      }
+    },
+    "roles": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "contract_store",
+          "record_consumer",
+          "event_source",
+          "event_consumer",
+          "action_caller",
+          "action_provider",
+          "bridge",
+          "runtime",
+          "runtime_store"
+        ]
+      }
+    },
+    "scenarios": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/testbed/v0.1/evidence.schema.json
+++ b/schemas/testbed/v0.1/evidence.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/testbed/v0.1/evidence.schema.json",
+  "title": "mdbase interoperability testbed evidence",
+  "type": "object",
+  "required": [
+    "kind",
+    "protocol_version",
+    "implementation",
+    "result",
+    "scenarios"
+  ],
+  "properties": {
+    "kind": { "const": "mdbase.testbed.evidence" },
+    "protocol_version": { "const": "0.1" },
+    "implementation": {
+      "$ref": "adapter-description.schema.json#/properties/implementation"
+    },
+    "result": { "enum": ["pass", "fail"] },
+    "scenarios": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "profile", "result", "transcript_digest"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+          },
+          "profile": {
+            "enum": [
+              "core_read",
+              "event_action_interop/0.1",
+              "runtime/0.2"
+            ]
+          },
+          "result": { "enum": ["pass", "fail"] },
+          "transcript_digest": {
+            "type": "string",
+            "pattern": "^sha256:[0-9a-f]{64}$"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/testbed/v0.1/fixture-catalog.schema.json
+++ b/schemas/testbed/v0.1/fixture-catalog.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/testbed/v0.1/fixture-catalog.schema.json",
+  "title": "mdbase interoperability testbed fixture catalog",
+  "type": "object",
+  "required": ["kind", "protocol_version", "fixtures"],
+  "properties": {
+    "kind": { "const": "mdbase.testbed.fixtures" },
+    "protocol_version": { "const": "0.1" },
+    "fixtures": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "required": ["kind", "value"],
+        "properties": {
+          "kind": {
+            "enum": ["contract", "type", "record", "workflow", "policy"]
+          },
+          "value": {}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/testbed/v0.1/run-request.schema.json
+++ b/schemas/testbed/v0.1/run-request.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/testbed/v0.1/run-request.schema.json",
+  "title": "mdbase interoperability testbed run request",
+  "type": "object",
+  "required": ["kind", "protocol_version", "scenario", "fixtures"],
+  "properties": {
+    "kind": { "const": "mdbase.testbed.run" },
+    "protocol_version": { "const": "0.1" },
+    "scenario": {
+      "$ref": "scenario.schema.json"
+    },
+    "fixtures": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["kind", "value"],
+        "properties": {
+          "kind": {
+            "enum": ["contract", "type", "record", "workflow", "policy"]
+          },
+          "value": {}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/testbed/v0.1/scenario.schema.json
+++ b/schemas/testbed/v0.1/scenario.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/testbed/v0.1/scenario.schema.json",
+  "title": "mdbase interoperability testbed scenario",
+  "type": "object",
+  "required": [
+    "kind",
+    "protocol_version",
+    "id",
+    "name",
+    "ring",
+    "profile",
+    "roles",
+    "operation",
+    "fixtures",
+    "parameters",
+    "covers",
+    "expect"
+  ],
+  "properties": {
+    "kind": { "const": "mdbase.testbed.scenario" },
+    "protocol_version": { "const": "0.1" },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+    },
+    "name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "ring": {
+      "enum": ["contract", "interop", "runtime"]
+    },
+    "profile": {
+      "enum": [
+        "core_read",
+        "event_action_interop/0.1",
+        "runtime/0.2"
+      ]
+    },
+    "roles": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "contract_store",
+          "record_consumer",
+          "event_source",
+          "event_consumer",
+          "action_caller",
+          "action_provider",
+          "bridge",
+          "runtime",
+          "runtime_store"
+        ]
+      }
+    },
+    "operation": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+    },
+    "fixtures": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+      }
+    },
+    "parameters": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "covers": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9._/-]+$"
+      }
+    },
+    "expect": {
+      "type": "object",
+      "required": ["entries"],
+      "properties": {
+        "entries": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/transcriptEntry"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "transcriptEntry": {
+      "type": "object",
+      "required": [
+        "sequence",
+        "phase",
+        "actor",
+        "operation",
+        "outcome",
+        "facts"
+      ],
+      "properties": {
+        "sequence": { "type": "integer", "minimum": 1 },
+        "phase": {
+          "enum": ["arrange", "act", "observe", "recover"]
+        },
+        "actor": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$"
+        },
+        "operation": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+        },
+        "outcome": {
+          "enum": [
+            "succeeded",
+            "rejected",
+            "failed",
+            "indeterminate",
+            "skipped"
+          ]
+        },
+        "facts": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/testbed/v0.1/transcript.schema.json
+++ b/schemas/testbed/v0.1/transcript.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/testbed/v0.1/transcript.schema.json",
+  "title": "mdbase interoperability testbed transcript",
+  "type": "object",
+  "required": [
+    "kind",
+    "protocol_version",
+    "scenario_id",
+    "implementation",
+    "entries"
+  ],
+  "properties": {
+    "kind": { "const": "mdbase.testbed.transcript" },
+    "protocol_version": { "const": "0.1" },
+    "scenario_id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+    },
+    "implementation": {
+      "type": "object",
+      "required": ["id", "name", "version"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[A-Za-z][A-Za-z0-9._:/-]*$"
+        },
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "language": { "type": "string", "minLength": 1 },
+        "target": { "type": "string", "minLength": 1 }
+      },
+      "patternProperties": {
+        "^x-[A-Za-z0-9._:-]+$": true
+      },
+      "additionalProperties": false
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/entry" }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "required": [
+        "sequence",
+        "phase",
+        "actor",
+        "operation",
+        "outcome",
+        "facts"
+      ],
+      "properties": {
+        "sequence": { "type": "integer", "minimum": 1 },
+        "phase": {
+          "enum": ["arrange", "act", "observe", "recover"]
+        },
+        "actor": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$"
+        },
+        "operation": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+        },
+        "outcome": {
+          "enum": [
+            "succeeded",
+            "rejected",
+            "failed",
+            "indeterminate",
+            "skipped"
+          ]
+        },
+        "facts": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/v0.3/conformance-claim.schema.json
+++ b/schemas/v0.3/conformance-claim.schema.json
@@ -85,14 +85,54 @@
         "type": "object",
         "required": ["kind", "command", "result", "verified_at"],
         "properties": {
-          "kind": { "enum": ["conformance_suite", "test_suite", "package_smoke", "manual_smoke"] },
+          "kind": {
+            "enum": [
+              "conformance_suite",
+              "test_suite",
+              "package_smoke",
+              "manual_smoke",
+              "testbed_transcript"
+            ]
+          },
           "command": { "type": "string", "minLength": 1 },
           "result": { "const": "pass" },
           "verified_at": { "type": "string", "format": "date-time" },
           "artifact": { "type": "string", "minLength": 1 },
-          "environment": { "type": "string", "minLength": 1 }
+          "environment": { "type": "string", "minLength": 1 },
+          "testbed_protocol_version": { "const": "0.1" },
+          "scenario_ids": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+            }
+          },
+          "evidence_digest": {
+            "type": "string",
+            "pattern": "^sha256:[0-9a-f]{64}$"
+          }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "kind": { "const": "testbed_transcript" }
+              },
+              "required": ["kind"]
+            },
+            "then": {
+              "required": [
+                "artifact",
+                "testbed_protocol_version",
+                "scenario_ids",
+                "evidence_digest"
+              ]
+            }
+          }
+        ]
       }
     }
   },

--- a/testbed/v0.1/README.md
+++ b/testbed/v0.1/README.md
@@ -1,0 +1,87 @@
+# mdbase interoperability testbed 0.1
+
+The testbed verifies observable behavior through a small process boundary. It
+does not require implementations to share a language, runtime, database, or
+plugin host, and it does not make fixture code authoritative.
+
+## The three rings
+
+1. **Contract** — load one record contract and type implementation, project one
+   record, and prove that multiple independent consumers receive the same
+   contract view.
+2. **Interop** — register live sources, consumers, callers, and providers; then
+   verify CloudEvents multicast, exact action admission, ambiguity, unload,
+   validation, authorization, and replay behavior.
+3. **Runtime** — exercise a durable store through crash recovery and competing
+   workers, including invocation reuse and lease fencing.
+
+Scenario JSON, not a particular implementation, defines the oracle. Every
+scenario names neutral fixtures from `fixtures/catalog.json` and contains its
+complete expected transcript. Volatile implementation details such as database
+keys, wall-clock time, and generated IDs are reduced to stable facts before
+comparison.
+
+## Adapter process protocol
+
+An adapter is an executable supporting two commands:
+
+```text
+adapter describe
+adapter run
+```
+
+`describe` writes one JSON document conforming to
+`adapter-description.schema.json`. For `run`, the testbed writes this JSON
+request to standard input:
+
+```json
+{
+  "kind": "mdbase.testbed.run",
+  "protocol_version": "0.1",
+  "scenario": {},
+  "fixtures": {}
+}
+```
+
+The adapter writes one transcript conforming to `transcript.schema.json`.
+Diagnostic logging belongs on standard error; standard output contains only the
+protocol document. Each `run` command is a fresh process, so scenarios cannot
+pass because of hidden state left by another scenario.
+
+Adapters MUST exercise public or documented implementation boundaries. They
+MUST NOT copy the expected transcript without observing the behavior it
+describes. A transcript is evidence of a named scenario, not authority to read,
+write, publish, subscribe, invoke, or provide.
+
+## Running
+
+From this repository:
+
+```bash
+npm test --prefix packages/testbed
+npm exec --prefix packages/testbed mdbase-testbed -- run --adapter reference
+```
+
+Against another implementation:
+
+```bash
+mdbase-testbed run --adapter ./path/to/adapter
+```
+
+If the adapter is launched through a language tool, use `command:NAME` and pass
+its fixed arguments separately. The runner never invokes a shell:
+
+```bash
+mdbase-testbed run --adapter command:cargo \
+  --adapter-arg run --adapter-arg --quiet \
+  --adapter-arg -p --adapter-arg my-testbed-adapter --adapter-arg --
+```
+
+Use `mdbase-testbed list` to inspect the portable scenario inventory and
+`mdbase-testbed validate` to validate every schema, fixture, scenario, and
+canonical expected transcript.
+
+Passing the testbed supplements the full v0.3 conformance suites. It does not by
+itself establish a complete profile claim: implementations still run every
+normative test for the profile they claim and attach the testbed transcript as
+machine-readable evidence.

--- a/testbed/v0.1/fixtures/catalog.json
+++ b/testbed/v0.1/fixtures/catalog.json
@@ -1,0 +1,175 @@
+{
+  "kind": "mdbase.testbed.fixtures",
+  "protocol_version": "0.1",
+  "fixtures": {
+    "contract.example-note": {
+      "kind": "contract",
+      "value": {
+        "kind": "mdbase.contract",
+        "contract_type": "record",
+        "id": "example.note",
+        "version": "1.0.0",
+        "name": "Portable example note",
+        "record_schema": {
+          "dialect": "json-schema-2020-12",
+          "value": {
+            "type": "object",
+            "required": ["title"],
+            "additionalProperties": false,
+            "properties": {
+              "title": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    "type.shared-note": {
+      "kind": "type",
+      "value": {
+        "kind": "mdbase.type",
+        "name": "shared_note",
+        "version": 1,
+        "schema": {
+          "dialect": "json-schema-2020-12",
+          "value": {
+            "type": "object",
+            "required": ["type", "headline"],
+            "properties": {
+              "type": { "const": "shared_note" },
+              "headline": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "implements": [
+          {
+            "contract": "example.note",
+            "version": "1.0.0",
+            "fields": {
+              "title": "headline"
+            }
+          }
+        ]
+      }
+    },
+    "record.shared-note": {
+      "kind": "record",
+      "value": {
+        "type": "shared_note",
+        "headline": "One record, two consumers"
+      }
+    },
+    "contract.record-changed": {
+      "kind": "contract",
+      "value": {
+        "kind": "mdbase.contract",
+        "contract_type": "event",
+        "id": "example.record.changed",
+        "version": "1.0.0",
+        "name": "Example record changed",
+        "data_schema": {
+          "dialect": "json-schema-2020-12",
+          "value": {
+            "type": "object",
+            "required": ["record_id", "revision"],
+            "additionalProperties": false,
+            "properties": {
+              "record_id": { "type": "string", "minLength": 1 },
+              "revision": { "type": "integer", "minimum": 1 }
+            }
+          }
+        }
+      }
+    },
+    "contract.record-annotate": {
+      "kind": "contract",
+      "value": {
+        "kind": "mdbase.contract",
+        "contract_type": "action",
+        "id": "example.record.annotate",
+        "version": "1.0.0",
+        "name": "Annotate example record",
+        "input_schema": {
+          "dialect": "json-schema-2020-12",
+          "value": {
+            "type": "object",
+            "required": ["record_id", "label"],
+            "additionalProperties": false,
+            "properties": {
+              "record_id": { "type": "string", "minLength": 1 },
+              "label": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "output_schema": {
+          "dialect": "json-schema-2020-12",
+          "value": {
+            "type": "object",
+            "required": ["record_id", "applied"],
+            "additionalProperties": false,
+            "properties": {
+              "record_id": { "type": "string", "minLength": 1 },
+              "applied": { "const": true }
+            }
+          }
+        },
+        "behavior": {
+          "idempotency": "required",
+          "cancellation": "cooperative"
+        }
+      }
+    },
+    "workflow.annotate-changed": {
+      "kind": "workflow",
+      "value": {
+        "type": "runtime_workflow",
+        "id": "example.annotate-changed",
+        "version": "1.0.0",
+        "name": "Annotate changed records",
+        "enabled": true,
+        "triggers": [
+          {
+            "id": "changed",
+            "event": {
+              "id": "example.record.changed",
+              "version": "^1.0.0"
+            }
+          }
+        ],
+        "steps": [
+          {
+            "id": "annotate",
+            "action": {
+              "id": "example.record.annotate",
+              "version": "^1.0.0"
+            },
+            "requires": {
+              "capabilities": ["record.write"]
+            },
+            "input": {
+              "record_id": { "$expr": "event.data.record_id" },
+              "label": "observed"
+            }
+          }
+        ]
+      }
+    },
+    "policy.allow-record-write": {
+      "kind": "policy",
+      "value": {
+        "type": "runtime_policy",
+        "id": "example.testbed-policy",
+        "version": "1.0.0",
+        "enabled": true,
+        "executors": {
+          "default": "testbed-runtime"
+        },
+        "grants": [
+          {
+            "capability": "record.write",
+            "mode": "allow"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/testbed/v0.1/scenarios/core.shared-contract-consumers.json
+++ b/testbed/v0.1/scenarios/core.shared-contract-consumers.json
@@ -1,0 +1,88 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "core.shared-contract-consumers",
+  "name": "Two applications consume one type implementation",
+  "description": "One type implements one record contract and two independent consumers observe the same projected contract view.",
+  "ring": "contract",
+  "profile": "core_read",
+  "roles": ["contract_store", "record_consumer"],
+  "operation": "contract.shared-consumers",
+  "fixtures": [
+    "contract.example-note",
+    "type.shared-note",
+    "record.shared-note"
+  ],
+  "parameters": {
+    "consumers": ["consumer-alpha", "consumer-beta"]
+  },
+  "covers": [
+    "core_read.data_contract_discovery",
+    "core_read.data_contract_implementation_validation",
+    "core_read.data_contract_projection"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "contract-store",
+        "operation": "contract.load",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.note",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "arrange",
+        "actor": "contract-store",
+        "operation": "type.load",
+        "outcome": "succeeded",
+        "facts": {
+          "type": "shared_note",
+          "implements": "example.note"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "consumer-alpha",
+        "operation": "contract-view.read",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.note",
+          "view": {
+            "title": "One record, two consumers"
+          }
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "act",
+        "actor": "consumer-beta",
+        "operation": "contract-view.read",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.note",
+          "view": {
+            "title": "One record, two consumers"
+          }
+        }
+      },
+      {
+        "sequence": 5,
+        "phase": "observe",
+        "actor": "testbed",
+        "operation": "contract-view.compare",
+        "outcome": "succeeded",
+        "facts": {
+          "consumers": 2,
+          "same_contract": true,
+          "same_view": true
+        }
+      }
+    ]
+  }
+}

--- a/testbed/v0.1/scenarios/interop.action-ambiguous.json
+++ b/testbed/v0.1/scenarios/interop.action-ambiguous.json
@@ -1,0 +1,52 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.action-ambiguous",
+  "name": "Multiple eligible providers are explicitly ambiguous",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["action_caller", "action_provider", "bridge"],
+  "operation": "interop.action-ambiguous",
+  "fixtures": ["contract.record-annotate"],
+  "parameters": {
+    "providers": ["provider-alpha", "provider-beta"]
+  },
+  "covers": [
+    "event_action_interop/0.1.explicit_provider_ambiguity"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "provider-alpha",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.annotate"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "arrange",
+        "actor": "provider-beta",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.annotate"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "rejected",
+        "facts": {
+          "code": "ambiguous_provider",
+          "provider_calls": 0
+        }
+      }
+    ]
+  }
+}

--- a/testbed/v0.1/scenarios/interop.action-explicit-provider.json
+++ b/testbed/v0.1/scenarios/interop.action-explicit-provider.json
@@ -1,0 +1,65 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.action-explicit-provider",
+  "name": "An explicit selector resolves provider ambiguity",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["action_caller", "action_provider", "bridge"],
+  "operation": "interop.action-explicit-provider",
+  "fixtures": ["contract.record-annotate"],
+  "parameters": {
+    "providers": ["provider-alpha", "provider-beta"],
+    "selected": "provider-beta"
+  },
+  "covers": [
+    "event_action_interop/0.1.explicit_provider_ambiguity",
+    "event_action_interop/0.1.exact_contract_and_provider_evidence"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "provider-alpha",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.annotate"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "arrange",
+        "actor": "provider-beta",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.annotate"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "succeeded",
+        "facts": {
+          "selected": "provider-beta"
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "observe",
+        "actor": "bridge",
+        "operation": "action.outcome",
+        "outcome": "succeeded",
+        "facts": {
+          "provider": "provider-beta",
+          "provider_alpha_calls": 0,
+          "provider_beta_calls": 1
+        }
+      }
+    ]
+  }
+}

--- a/testbed/v0.1/scenarios/interop.action-single-provider.json
+++ b/testbed/v0.1/scenarios/interop.action-single-provider.json
@@ -1,0 +1,57 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.action-single-provider",
+  "name": "A single eligible provider is invoked",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["action_caller", "action_provider", "bridge"],
+  "operation": "interop.action-single-provider",
+  "fixtures": ["contract.record-annotate"],
+  "parameters": {
+    "request_id": "req-single-1",
+    "provider": "provider-alpha"
+  },
+  "covers": [
+    "event_action_interop/0.1.action_request_admission_and_outcome",
+    "event_action_interop/0.1.exact_contract_and_provider_evidence"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "provider-alpha",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.annotate",
+          "idempotency": "request"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "succeeded",
+        "facts": {
+          "request_id": "req-single-1"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "observe",
+        "actor": "bridge",
+        "operation": "action.outcome",
+        "outcome": "succeeded",
+        "facts": {
+          "exact_contract": true,
+          "provider": "provider-alpha",
+          "provider_calls": 1,
+          "request_id": "req-single-1"
+        }
+      }
+    ]
+  }
+}

--- a/testbed/v0.1/scenarios/interop.application-event-multicast.json
+++ b/testbed/v0.1/scenarios/interop.application-event-multicast.json
@@ -1,0 +1,75 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.application-event-multicast",
+  "name": "An application event source reaches two independent consumers",
+  "description": "A real application-owned event contract is multicast without making its product-specific payload part of the neutral oracle.",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["event_source", "event_consumer", "bridge"],
+  "operation": "interop.application-event-multicast",
+  "fixtures": [],
+  "parameters": {},
+  "covers": [
+    "event_action_interop/0.1.cloudevents_event_envelope",
+    "event_action_interop/0.1.event_multicast_and_version_resolution",
+    "event_action_interop/0.1.boundary_validation"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "application",
+        "operation": "contract.describe",
+        "outcome": "succeeded",
+        "facts": {
+          "contract_type": "event",
+          "schema": "json-schema-2020-12"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "arrange",
+        "actor": "application",
+        "operation": "event-source.register",
+        "outcome": "succeeded",
+        "facts": {
+          "sources": 1
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "arrange",
+        "actor": "consumers",
+        "operation": "event.subscribe",
+        "outcome": "succeeded",
+        "facts": {
+          "consumers": 2
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "act",
+        "actor": "application",
+        "operation": "event.publish",
+        "outcome": "succeeded",
+        "facts": {
+          "exact_contract": true,
+          "specversion": "1.0"
+        }
+      },
+      {
+        "sequence": 5,
+        "phase": "observe",
+        "actor": "bridge",
+        "operation": "event.deliver",
+        "outcome": "succeeded",
+        "facts": {
+          "deliveries": 2,
+          "distinct_consumers": 2
+        }
+      }
+    ]
+  }
+}

--- a/testbed/v0.1/scenarios/interop.application-provider-lifecycle.json
+++ b/testbed/v0.1/scenarios/interop.application-provider-lifecycle.json
@@ -1,0 +1,84 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.application-provider-lifecycle",
+  "name": "An application provider validates, invokes, and unloads cleanly",
+  "description": "A real application-owned action contract is exercised without making its product-specific contract part of the neutral oracle.",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["action_caller", "action_provider", "bridge"],
+  "operation": "interop.application-provider-lifecycle",
+  "fixtures": [],
+  "parameters": {},
+  "covers": [
+    "event_action_interop/0.1.action_request_admission_and_outcome",
+    "event_action_interop/0.1.boundary_validation",
+    "event_action_interop/0.1.cancellation_and_unload"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "application",
+        "operation": "contract.describe",
+        "outcome": "succeeded",
+        "facts": {
+          "contract_type": "action",
+          "schema": "json-schema-2020-12"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "arrange",
+        "actor": "application",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "providers": 1
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "succeeded",
+        "facts": {
+          "exact_contract": true,
+          "provider_calls": 1
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "act",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "rejected",
+        "facts": {
+          "code": "invalid_action_input"
+        }
+      },
+      {
+        "sequence": 5,
+        "phase": "act",
+        "actor": "application",
+        "operation": "client.dispose",
+        "outcome": "succeeded",
+        "facts": {
+          "providers": 0
+        }
+      },
+      {
+        "sequence": 6,
+        "phase": "observe",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "rejected",
+        "facts": {
+          "code": "no_provider"
+        }
+      }
+    ]
+  }
+}

--- a/testbed/v0.1/scenarios/interop.authority-boundary.json
+++ b/testbed/v0.1/scenarios/interop.authority-boundary.json
@@ -1,0 +1,51 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.authority-boundary",
+  "name": "Contract compatibility never grants provider authority",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["action_provider", "bridge"],
+  "operation": "interop.authority-boundary",
+  "fixtures": ["contract.record-annotate"],
+  "parameters": {
+    "denied_application": "untrusted-provider"
+  },
+  "covers": [
+    "event_action_interop/0.1.independent_authorization"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "untrusted-provider",
+        "operation": "contract.validate",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.annotate"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "untrusted-provider",
+        "operation": "action-provider.register",
+        "outcome": "rejected",
+        "facts": {
+          "code": "unauthorized"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "observe",
+        "actor": "bridge",
+        "operation": "registry.inspect",
+        "outcome": "succeeded",
+        "facts": {
+          "providers": 0
+        }
+      }
+    ]
+  }
+}

--- a/testbed/v0.1/scenarios/interop.contract-digest-drift.json
+++ b/testbed/v0.1/scenarios/interop.contract-digest-drift.json
@@ -1,0 +1,53 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.contract-digest-drift",
+  "name": "Digest drift for one exact contract identity fails atomically",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["event_source", "bridge"],
+  "operation": "interop.contract-digest-drift",
+  "fixtures": ["contract.record-changed"],
+  "parameters": {
+    "mutate": "data_schema.value.properties.record_id.minLength"
+  },
+  "covers": [
+    "event_action_interop/0.1.first_class_event_and_action_contracts",
+    "event_action_interop/0.1.boundary_validation"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "source-alpha",
+        "operation": "event-source.register",
+        "outcome": "succeeded",
+        "facts": {
+          "sources": 1
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "source-beta",
+        "operation": "event-source.register",
+        "outcome": "rejected",
+        "facts": {
+          "code": "contract_digest_conflict"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "observe",
+        "actor": "bridge",
+        "operation": "registry.inspect",
+        "outcome": "succeeded",
+        "facts": {
+          "atomic": true,
+          "sources": 1
+        }
+      }
+    ]
+  }
+}

--- a/testbed/v0.1/scenarios/interop.event-multicast.json
+++ b/testbed/v0.1/scenarios/interop.event-multicast.json
@@ -1,0 +1,78 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.event-multicast",
+  "name": "One event is multicast to every compatible consumer",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["event_source", "event_consumer", "bridge"],
+  "operation": "interop.event-multicast",
+  "fixtures": ["contract.record-changed"],
+  "parameters": {
+    "event_id": "evt-shared-1",
+    "consumers": ["consumer-alpha", "consumer-beta"]
+  },
+  "covers": [
+    "event_action_interop/0.1.cloudevents_event_envelope",
+    "event_action_interop/0.1.event_multicast_and_version_resolution"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "source",
+        "operation": "event-source.register",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.changed",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "arrange",
+        "actor": "consumer-alpha",
+        "operation": "event.subscribe",
+        "outcome": "succeeded",
+        "facts": {
+          "version": "^1.0.0"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "arrange",
+        "actor": "consumer-beta",
+        "operation": "event.subscribe",
+        "outcome": "succeeded",
+        "facts": {
+          "version": ">=1.0.0 <2.0.0"
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "act",
+        "actor": "source",
+        "operation": "event.publish",
+        "outcome": "succeeded",
+        "facts": {
+          "event_id": "evt-shared-1"
+        }
+      },
+      {
+        "sequence": 5,
+        "phase": "observe",
+        "actor": "bridge",
+        "operation": "event.deliver",
+        "outcome": "succeeded",
+        "facts": {
+          "consumers": ["consumer-alpha", "consumer-beta"],
+          "deliveries": 2,
+          "duplicate": false,
+          "exact_contract": true,
+          "specversion": "1.0"
+        }
+      }
+    ]
+  }
+}

--- a/testbed/v0.1/scenarios/interop.invalid-payload.json
+++ b/testbed/v0.1/scenarios/interop.invalid-payload.json
@@ -1,0 +1,63 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.invalid-payload",
+  "name": "Invalid event data is rejected before delivery",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["event_source", "event_consumer", "bridge"],
+  "operation": "interop.invalid-payload",
+  "fixtures": ["contract.record-changed"],
+  "parameters": {
+    "data": {
+      "record_id": "note-1"
+    }
+  },
+  "covers": [
+    "event_action_interop/0.1.boundary_validation"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "source",
+        "operation": "event-source.register",
+        "outcome": "succeeded",
+        "facts": {
+          "contract": "example.record.changed"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "arrange",
+        "actor": "consumer",
+        "operation": "event.subscribe",
+        "outcome": "succeeded",
+        "facts": {
+          "version": "^1.0.0"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "source",
+        "operation": "event.publish",
+        "outcome": "rejected",
+        "facts": {
+          "code": "invalid_event_data"
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "observe",
+        "actor": "consumer",
+        "operation": "event.deliver",
+        "outcome": "skipped",
+        "facts": {
+          "deliveries": 0
+        }
+      }
+    ]
+  }
+}

--- a/testbed/v0.1/scenarios/interop.provider-disappearance.json
+++ b/testbed/v0.1/scenarios/interop.provider-disappearance.json
@@ -1,0 +1,52 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.provider-disappearance",
+  "name": "Unloading a provider removes it from admission",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["action_caller", "action_provider", "bridge"],
+  "operation": "interop.provider-disappearance",
+  "fixtures": ["contract.record-annotate"],
+  "parameters": {
+    "provider": "provider-alpha"
+  },
+  "covers": [
+    "event_action_interop/0.1.cancellation_and_unload"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "provider-alpha",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "providers": 1
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "provider-alpha",
+        "operation": "client.dispose",
+        "outcome": "succeeded",
+        "facts": {
+          "providers": 0
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "observe",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "rejected",
+        "facts": {
+          "code": "no_provider",
+          "provider_calls": 0
+        }
+      }
+    ]
+  }
+}

--- a/testbed/v0.1/scenarios/interop.request-replay.json
+++ b/testbed/v0.1/scenarios/interop.request-replay.json
@@ -1,0 +1,63 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "interop.request-replay",
+  "name": "A declared idempotent request reuses its recorded outcome",
+  "ring": "interop",
+  "profile": "event_action_interop/0.1",
+  "roles": ["action_caller", "action_provider", "bridge"],
+  "operation": "interop.request-replay",
+  "fixtures": ["contract.record-annotate"],
+  "parameters": {
+    "request_id": "req-replay-1",
+    "idempotency_key": "run-1:annotate"
+  },
+  "covers": [
+    "event_action_interop/0.1.duplicate_and_indeterminate_semantics"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "provider-alpha",
+        "operation": "action-provider.register",
+        "outcome": "succeeded",
+        "facts": {
+          "idempotency": "request"
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "caller",
+        "operation": "action.invoke",
+        "outcome": "succeeded",
+        "facts": {
+          "request_id": "req-replay-1"
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "caller",
+        "operation": "action.replay",
+        "outcome": "succeeded",
+        "facts": {
+          "request_id": "req-replay-1"
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "observe",
+        "actor": "bridge",
+        "operation": "action.outcome",
+        "outcome": "succeeded",
+        "facts": {
+          "handler_calls": 1,
+          "same_outcome": true
+        }
+      }
+    ]
+  }
+}

--- a/testbed/v0.1/scenarios/runtime.application-execution.json
+++ b/testbed/v0.1/scenarios/runtime.application-execution.json
@@ -1,0 +1,75 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "runtime.application-execution",
+  "name": "An application-owned runtime executes one exact admitted effect",
+  "description": "A product runtime composes its real contracts, admits an exact source/provider plan, authorizes dispatch, and persists one successful run.",
+  "ring": "runtime",
+  "profile": "runtime/0.2",
+  "roles": ["event_source", "action_provider", "runtime", "runtime_store"],
+  "operation": "runtime.application-execution",
+  "fixtures": [],
+  "parameters": {},
+  "covers": [
+    "runtime/0.2.exact_contract_source_and_provider_admission",
+    "runtime/0.2.dispatch_authorization",
+    "runtime/0.2.durable_event_admission"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "application-runtime",
+        "operation": "catalog.compose",
+        "outcome": "succeeded",
+        "facts": {
+          "contracts_verified": true,
+          "executor_selected": true
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "event-source",
+        "operation": "event.publish",
+        "outcome": "succeeded",
+        "facts": {
+          "exact_contract": true
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "application-runtime",
+        "operation": "event.admit",
+        "outcome": "succeeded",
+        "facts": {
+          "runs": 1
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "act",
+        "actor": "action-provider",
+        "operation": "action.dispatch",
+        "outcome": "succeeded",
+        "facts": {
+          "authorization_checked": true,
+          "provider_calls": 1
+        }
+      },
+      {
+        "sequence": 5,
+        "phase": "observe",
+        "actor": "runtime-store",
+        "operation": "run.inspect",
+        "outcome": "succeeded",
+        "facts": {
+          "exact_bindings": true,
+          "status": "succeeded"
+        }
+      }
+    ]
+  }
+}

--- a/testbed/v0.1/scenarios/runtime.competing-workers.json
+++ b/testbed/v0.1/scenarios/runtime.competing-workers.json
@@ -1,0 +1,82 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "runtime.competing-workers",
+  "name": "Competing workers are fenced by one durable lease",
+  "ring": "runtime",
+  "profile": "runtime/0.2",
+  "roles": ["runtime", "runtime_store"],
+  "operation": "runtime.competing-workers",
+  "fixtures": [
+    "contract.record-changed",
+    "contract.record-annotate",
+    "workflow.annotate-changed",
+    "policy.allow-record-write"
+  ],
+  "parameters": {
+    "event_id": "evt-fence-1",
+    "workers": ["worker-alpha", "worker-beta"]
+  },
+  "covers": [
+    "runtime/0.2.idempotency_and_concurrency",
+    "runtime/0.2.lease_and_crash_recovery",
+    "runtime/0.2.run_state_machine"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "runtime",
+        "operation": "event.admit",
+        "outcome": "succeeded",
+        "facts": {
+          "event_id": "evt-fence-1",
+          "runs": 1
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "worker-alpha",
+        "operation": "run.claim",
+        "outcome": "succeeded",
+        "facts": {
+          "claims": 1
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "act",
+        "actor": "worker-beta",
+        "operation": "run.claim",
+        "outcome": "skipped",
+        "facts": {
+          "claims": 0
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "recover",
+        "actor": "worker-alpha",
+        "operation": "run.commit",
+        "outcome": "rejected",
+        "facts": {
+          "code": "stale_lease"
+        }
+      },
+      {
+        "sequence": 5,
+        "phase": "observe",
+        "actor": "runtime-store",
+        "operation": "run.inspect",
+        "outcome": "succeeded",
+        "facts": {
+          "concurrent_claims": 1,
+          "runs": 1,
+          "winner": "worker-beta"
+        }
+      }
+    ]
+  }
+}

--- a/testbed/v0.1/scenarios/runtime.crash-recovery.json
+++ b/testbed/v0.1/scenarios/runtime.crash-recovery.json
@@ -1,0 +1,73 @@
+{
+  "kind": "mdbase.testbed.scenario",
+  "protocol_version": "0.1",
+  "id": "runtime.crash-recovery",
+  "name": "An unknown idempotent dispatch recovers without a duplicate effect",
+  "ring": "runtime",
+  "profile": "runtime/0.2",
+  "roles": ["runtime", "runtime_store", "action_provider"],
+  "operation": "runtime.crash-recovery",
+  "fixtures": [
+    "contract.record-changed",
+    "contract.record-annotate",
+    "workflow.annotate-changed",
+    "policy.allow-record-write"
+  ],
+  "parameters": {
+    "event_id": "evt-crash-1",
+    "failpoint": "after_provider_effect_before_result_commit",
+    "expire_lease": true
+  },
+  "covers": [
+    "runtime/0.2.durable_action_attempts",
+    "runtime/0.2.lease_and_crash_recovery"
+  ],
+  "expect": {
+    "entries": [
+      {
+        "sequence": 1,
+        "phase": "arrange",
+        "actor": "runtime",
+        "operation": "event.admit",
+        "outcome": "succeeded",
+        "facts": {
+          "event_id": "evt-crash-1",
+          "runs": 1
+        }
+      },
+      {
+        "sequence": 2,
+        "phase": "act",
+        "actor": "worker-alpha",
+        "operation": "action.dispatch",
+        "outcome": "indeterminate",
+        "facts": {
+          "provider_effects": 1
+        }
+      },
+      {
+        "sequence": 3,
+        "phase": "recover",
+        "actor": "worker-beta",
+        "operation": "lease.recover",
+        "outcome": "succeeded",
+        "facts": {
+          "same_attempt_id": true,
+          "same_invocation_id": true
+        }
+      },
+      {
+        "sequence": 4,
+        "phase": "observe",
+        "actor": "runtime-store",
+        "operation": "run.inspect",
+        "outcome": "succeeded",
+        "facts": {
+          "dispatches": 2,
+          "logical_effects": 1,
+          "status": "succeeded"
+        }
+      }
+    ]
+  }
+}

--- a/tests/v0.3/fixtures/conformance/valid-testbed-evidence.yml
+++ b/tests/v0.3/fixtures/conformance/valid-testbed-evidence.yml
@@ -1,0 +1,27 @@
+kind: mdbase.conformance
+status: verified
+implementation:
+  id: example.core
+  name: Example core implementation
+  version: 1.0.0
+spec_version: 0.3.0-rc.4
+profiles:
+  - core_read
+json_schema:
+  dialect: https://json-schema.org/draft/2020-12/schema
+  keywords: [type, required, properties]
+  formats: [date-time]
+  remote_refs: false
+limits:
+  max_record_bytes: 1048576
+evidence:
+  - kind: testbed_transcript
+    command: mdbase-testbed run --adapter ./example-adapter --evidence evidence.json
+    result: pass
+    verified_at: "2026-07-29T00:00:00Z"
+    artifact: evidence.json
+    environment: Node.js 22 on Linux
+    testbed_protocol_version: "0.1"
+    scenario_ids:
+      - core.shared-contract-consumers
+    evidence_digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/tests/v0.3/schema/schema-artifacts.yaml
+++ b/tests/v0.3/schema/schema-artifacts.yaml
@@ -60,6 +60,15 @@ groups:
         expect:
           valid: true
 
+      - name: "conformance claim schema accepts digest-bound testbed evidence"
+        operation: yaml_document_schema_validate
+        input:
+          schema: "schemas/v0.3/conformance-claim.schema.json"
+          paths:
+            - "tests/v0.3/fixtures/conformance/valid-testbed-evidence.yml"
+        expect:
+          valid: true
+
       - name: "conformance claim schema rejects missing profile dependencies"
         operation: yaml_document_schema_validate
         input:
@@ -212,5 +221,33 @@ groups:
           schema: "schemas/v0.3/type-pack.schema.json"
           paths:
             - "standard-packs/mdbase-runtime/0.2.0/mdbase-pack.yaml"
+        expect:
+          valid: true
+
+  - name: "portable interoperability testbed"
+    tests:
+      - name: "all testbed protocol schemas validate against JSON Schema 2020-12"
+        operation: json_schema_meta_validate
+        input:
+          paths:
+            - "schemas/testbed/v0.1/*.schema.json"
+        expect:
+          valid: true
+
+      - name: "the neutral fixture catalog validates"
+        operation: json_document_schema_validate
+        input:
+          schema: "schemas/testbed/v0.1/fixture-catalog.schema.json"
+          paths:
+            - "testbed/v0.1/fixtures/catalog.json"
+        expect:
+          valid: true
+
+      - name: "every portable scenario validates"
+        operation: json_document_schema_validate
+        input:
+          schema: "schemas/testbed/v0.1/scenario.schema.json"
+          paths:
+            - "testbed/v0.1/scenarios/*.json"
         expect:
           valid: true


### PR DESCRIPTION
## What changed

- Defines a versioned, product-neutral black-box testbed protocol with Draft 2020-12 schemas for adapters, scenarios, fixtures, transcripts, requests, and evidence.
- Adds 15 canonical scenarios across contract, live interoperability, and durable runtime rings.
- Ships `@callumalpass/mdbase-testbed` with a shell-free process runner, a real reference adapter, exact transcript comparison, useful first-difference diagnostics, and digest-bound evidence.
- Extends v0.3 conformance claims with `testbed_transcript` evidence and documents the authority boundary.
- Runs the reference suite and package checks on Linux, macOS, and Windows.

## Why

The normative fixtures prove individual requirements, but ecosystem implementations also need comparable observable evidence across languages and product boundaries. The adapter boundary lets implementations keep their own architecture while testing the same contract, multicast, provider-resolution, validation, replay, recovery, and fencing behavior.

## Developer and user impact

Implementers can add two process commands (`describe` and `run`) and exercise the suite without linking to a particular language runtime. Users can inspect neutral JSON scenarios and attach portable transcript evidence to a conformance claim. Passing never grants authority and does not replace a complete profile claim.

## Validation

- `npm test` in `packages/testbed` (15 scenarios; 9 reference scenarios)
- `npm pack --dry-run` from a clean generated `dist` boundary
- `python3 scripts/check_v03_tests.py` (61 executable tests, 95 adapter targets)
- `npm run build --prefix site`
- Downstream black-box adapters passed in mdbase TypeScript, mdbase Rust, mdbase Connect, TaskNotes Workflows, Canvas Bases, and the local TaskNotes v5 branch.
